### PR TITLE
NtupleReader for both Spring15 and PHY14

### DIFF
--- a/Tools/NTupleReader.cc
+++ b/Tools/NTupleReader.cc
@@ -22,7 +22,7 @@ NTupleReader::NTupleReader(TTree * tree)
 void NTupleReader::init()
 {
     //gROOT->ProcessLine(".L TupleDict.h+");
-    gInterpreter->GenerateDictionary("vector<TLorentzVector>","TLorentzVector.h;vector");
+    //gInterpreter->GenerateDictionary("vector<TLorentzVector>","TLorentzVector.h;vector");
 
     nEvtTotal_ = tree_->GetEntries();
     nevt_ = 0;

--- a/Tools/NTupleReader.h
+++ b/Tools/NTupleReader.h
@@ -48,6 +48,11 @@ public:
         return nevt_;
     }
 
+    bool IsFirstEvent() const
+    {
+      return isFirstEvent_;
+    }
+
     int getNEntries() const
     {
         if(tree_) return nEvtTotal_;
@@ -121,6 +126,14 @@ public:
 
         return *getTupleObj<std::vector<T>*>(var, branchVecMap_);
     }
+
+    template<typename T, typename V> const std::map<T, V>& getMap(const std::string var) const
+    {
+        //This function can be used to return vectors
+
+        return *getTupleObj<std::map<T, V>*>(var, branchVecMap_);
+    }
+ 
  
 private:
     // private variables for internal use
@@ -192,6 +205,7 @@ private:
         }
 
         if(isFirstEvent_) printf("NTupleReader::getTupleObj(const std::string var):  Variable not found: \"%s\"!!!\n", var.c_str());
+        throw var;
         return *static_cast<T*>(nullptr);
     }
 

--- a/Tools/baselineDef.h
+++ b/Tools/baselineDef.h
@@ -43,15 +43,15 @@ public:
         try
         {
           const double &temp  = tr.getVar<double>("genHT");
-          muonsFlagIDLabel = "";
         }
         catch (std::string var)
         {
           if(tr.IsFirstEvent()) 
           {
             printf("NTupleReader::getTupleObj(const std::string var):  Variable not found: \"%s\"!!!\n", var.c_str());
-            printf("Running with PHYS14 Config");
+            printf("Running with PHYS14 Config\n");
           }
+          muonsFlagIDLabel = "";
         }
         std::string elesFlagIDLabel = "";
 
@@ -271,7 +271,7 @@ public:
         if(tr.IsFirstEvent()) 
         {
           printf("NTupleReader::getTupleObj(const std::string var):  Variable not found: \"%s\"!!!\n", var.c_str());
-          printf("Running with PHYS14 Config");
+          printf("Running with PHYS14 Config\n");
         }
       }
       return true;

--- a/Tools/baselineDef.h
+++ b/Tools/baselineDef.h
@@ -40,6 +40,19 @@ public:
         std::string METPhiLabel = "metphi";
 
         std::string muonsFlagIDLabel = "muonsFlagMedium";
+        try
+        {
+          const double &temp  = tr.getVar<double>("genHT");
+          muonsFlagIDLabel = "";
+        }
+        catch (std::string var)
+        {
+          if(tr.IsFirstEvent()) 
+          {
+            printf("NTupleReader::getTupleObj(const std::string var):  Variable not found: \"%s\"!!!\n", var.c_str());
+            printf("Running with PHYS14 Config");
+          }
+        }
         std::string elesFlagIDLabel = "";
 
         if( spec.compare("noIsoTrksVeto") == 0)
@@ -242,14 +255,26 @@ public:
     } 
 
     bool passNoiseEventFilterFunc(NTupleReader &tr){
-       int jetIDFilter = tr.getVar<int>("prodJetIDEventFilter");
-       int beamHaloFilter = tr.getVar<int>("CSCTightHaloFilter");
-       int ecalTPFilter = tr.getVar<int>("EcalDeadCellTriggerPrimitiveFilter");
-       bool hbheNoiseFilter = tr.getVar<bool>("HBHENoiseFilter");
-       int vtxSize = tr.getVar<int>("vtxSize");
+      try
+      {
+        int jetIDFilter = tr.getVar<int>("prodJetIDEventFilter");
+        int beamHaloFilter = tr.getVar<int>("CSCTightHaloFilter");
+        int ecalTPFilter = tr.getVar<int>("EcalDeadCellTriggerPrimitiveFilter");
+        bool hbheNoiseFilter = tr.getVar<bool>("HBHENoiseFilter");
+        int vtxSize = tr.getVar<int>("vtxSize");
 
-//       return (vtxSize>=1) && beamHaloFilter && ecalTPFilter && hbheNoiseFilter && jetIDFilter;
-       return (vtxSize>=1) && beamHaloFilter && ecalTPFilter && hbheNoiseFilter;
+        //return (vtxSize>=1) && beamHaloFilter && ecalTPFilter && hbheNoiseFilter && jetIDFilter;
+        return (vtxSize>=1) && beamHaloFilter && ecalTPFilter && hbheNoiseFilter;
+      }
+      catch (std::string var)
+      {
+        if(tr.IsFirstEvent()) 
+        {
+          printf("NTupleReader::getTupleObj(const std::string var):  Variable not found: \"%s\"!!!\n", var.c_str());
+          printf("Running with PHYS14 Config");
+        }
+      }
+      return true;
     }
 
     void operator()(NTupleReader &tr)

--- a/Tools/samples.cc
+++ b/Tools/samples.cc
@@ -19,7 +19,7 @@ namespace AnaSamples
             }
             fclose(f);
         }
-        else std::cout << "Filelist file \"" << filePath << "\" not found!!!!!!!" << std::endl;
+        //else std::cout << "Filelist file \"" << filePath << "\" not found!!!!!!!" << std::endl;
     }
 
     SampleSet::SampleSet(std::string fDir, double lumi) : fDir_(fDir), lumi_(lumi)

--- a/Tools/samples.h
+++ b/Tools/samples.h
@@ -74,8 +74,8 @@ namespace AnaSamples
         }
 
         const T& null() const {return nullT_;}
-    protected:
         std::map<std::string, T> sampleSet_;
+    protected:
         const T nullT_;
 
     public:


### PR DESCRIPTION
Propose to just merge the NtupleReader.h and baselineDef.h, in case other uses
needed. 

Using a throw to catch the expectation when running on PHYS14 samples
Added a getMap function to retrieve the std::map without casted to vector<pair>

Please rebase the other changes in files, which is needed for my own framework
