### PR TITLE
New samples and counting of neg weights

### DIFF
--- a/Tools/Makefile
+++ b/Tools/Makefile
@@ -52,7 +52,7 @@ $(ODIR)/%.o : $(SDIR)/%.cc
 tupleTest: $(ODIR)/NTupleReader.o $(ODIR)/PDFUncertainty.o $(ODIR)/tupleReadTest.o 
 	$(LD) $^ $(LIBS) $(MT2LIB) $(LHAPDFLIB) -o $@
 
-nEvts: $(ODIR)/samples.o $(ODIR)/nEvts.o
+nEvts: $(ODIR)/samples.o $(ODIR)/NTupleReader.o $(ODIR)/nEvts.o
 	$(LD) $^ $(LIBS) -o $@
 
 basicCheck: $(ODIR)/NTupleReader.o $(ODIR)/samples.o $(ODIR)/basicCheck.o

--- a/Tools/nEvts.C
+++ b/Tools/nEvts.C
@@ -1,4 +1,5 @@
 #include "samples.h"
+#include "NTupleReader.h"
 
 #include "TFile.h"
 #include "TTree.h"
@@ -6,16 +7,37 @@
 
 #include <iostream>
 #include <sstream>
+#include <getopt.h>
 
 int main(int argc, char *argv[])
 {
+    int opt;
+    int option_index = 0;
+    static struct option long_options[] = {
+	{"negw", no_argument, 0, 'w'}
+    };
+
+    bool getNegWeights = false;
+    while((opt=getopt_long(argc, argv, "w", long_options, &option_index)) != -1)
+    {
+	switch(opt)
+	{
+	case 'w':
+	    getNegWeights = true;
+	    break;
+	}
+    }
+    if(getNegWeights)
+	std::cout << "Will compute negative weight fraction" << std::endl;
+    
     AnaSamples::SampleSet        ss;
     AnaSamples::SampleCollection sc(ss);
 
     std::string selKeyStr;
-    if( argc ==2 ){
-       selKeyStr = argv[1];
-       std::cout<<"selKeyStr : "<<selKeyStr<<std::endl;
+    if(argc >= optind+1)
+    {
+	selKeyStr = argv[optind];
+	std::cout << "selKeyStr : " << selKeyStr << std::endl;
     }
 
     std::stringstream ssSelKey(selKeyStr);
@@ -37,6 +59,25 @@ int main(int argc, char *argv[])
         file.second.addFilesToChain(t);
      
         std::cout << "Processing file(s): " << file.second.filePath << "\t" << t->GetEntries() << std::endl;
+
+	if(getNegWeights)
+	{
+	    std::set<std::string> activeBranches;
+	    activeBranches.insert("stored_weight");
+	    NTupleReader tr = NTupleReader(t, activeBranches);
+
+	    int negw = 0;
+	    int posw = 0;
+	    while(tr.getNextEvent())
+	    {
+		double stored_weight = tr.getVar<double>("stored_weight");
+		if(stored_weight > 0)
+		    ++posw;
+		else
+		    ++negw;
+	    }
+	    std::cout << "Processing file(s): " << file.second.filePath << "\t" << "Neg weigths = " << negw << ", Pos weights = " << posw << std::endl;
+	}
     }
      
 }

--- a/Tools/samples.cc
+++ b/Tools/samples.cc
@@ -129,30 +129,30 @@ namespace AnaSamples
         // NLO --> negative weights!
         // (sign of gen weight) * (lumi*xsec)/(effective number of events): effective number of events = N(evt) with positive weight - N(evt) with negative weight
         sampleSet_["TTZToLLNuNu"]         = FileSummary(fDir_ + MCloc + "TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt", "stopTreeMaker/AUX", 0.2529, lumi, 291495 - 106505,  1.0,  kOrange+2);
-        sampleSet_["TTZToQQ"]             = FileSummary(fDir_ + MCloc + "TTZToQQ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt", "stopTreeMaker/AUX", 0.5297, lumi, 550599 - 199201,  1.0,  kOrange+2);
+        sampleSet_["TTZToQQ"]             = FileSummary(fDir_ + MCloc + "TTZToQQ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt",          "stopTreeMaker/AUX", 0.5297, lumi, 550599 - 199201,  1.0,  kOrange+2);
 
         // NLO --> negative weights!
         sampleSet_["TTWJetsToLNu"]        = FileSummary(fDir_ + MCloc + "TTWJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8.txt", "stopTreeMaker/AUX", 0.2043, lumi, 191379 - 61529,   1.0,  kSpring+2);
         sampleSet_["TTWJetsToQQ"]         = FileSummary(fDir_ + MCloc + "TTWJetsToQQ_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8.txt",  "stopTreeMaker/AUX", 0.4062, lumi, 632147 - 201817,  1.0,  kSpring+2);
 
-        // NLO --> negative weights! Still need to taken them into account
-        sampleSet_["TTGJets"]             = FileSummary(fDir_ + MCloc + "TTGJets_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8.txt", "stopTreeMaker/AUX", 3.697, lumi, 4832230,  1.0,  kSpring+2);
+        // NLO --> negative weights! 
+        sampleSet_["TTGJets"]             = FileSummary(fDir_ + MCloc + "TTGJets_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8.txt", "stopTreeMaker/AUX", 3.697, lumi,  3199309 - 1632921,  1.0,  kSpring+2);
 
-        // ttH --> negative weights! Still need to take them into account
-	sampleSet_["ttHJetTobb"]     = FileSummary(fDir_ + MCloc + "ttHJetTobb_M125_13TeV_amcatnloFXFX_madspin_pythia8.txt",             "stopTreeMaker/AUX", 0.2934,  lumi, 1612604,  1.0,  kOrange+2);
-	sampleSet_["ttHJetToNonbb"]  = FileSummary(fDir_ + MCloc + "ttHJetToNonbb_M125_13TeV_amcatnloFXFX_madspin_pythia8_mWCutfix.txt", "stopTreeMaker/AUX", 0.2151,  lumi, 8025223,  1.0,  kOrange+2);
+        // ttH --> negative weights!
+	sampleSet_["ttHJetTobb"]     = FileSummary(fDir_ + MCloc + "ttHJetTobb_M125_13TeV_amcatnloFXFX_madspin_pythia8.txt",             "stopTreeMaker/AUX", 0.2934,  lumi, 1047463 - 565141,   1.0,  kOrange+2);
+	sampleSet_["ttHJetToNonbb"]  = FileSummary(fDir_ + MCloc + "ttHJetToNonbb_M125_13TeV_amcatnloFXFX_madspin_pythia8_mWCutfix.txt", "stopTreeMaker/AUX", 0.2151,  lumi, 5206759 - 2818464,  1.0,  kOrange+2);
         
-        // Di-boson?
+        // Di-boson
 	// Ref. https://indico.cern.ch/event/439995/session/0/contribution/6/attachments/1143460/1638648/diboson_final.pdf (NNLO is given)
         sampleSet_["WW"]              = FileSummary(fDir_ + MCloc + "WW_TuneCUETP8M1_13TeV-pythia8.txt", "stopTreeMaker/AUX", 115.0,  lumi, 993640,  1.0,  kOrange+4); 
 	// Ref. https://twiki.cern.ch/twiki/bin/viewauth/CMS/SummaryTable1G25ns (NLO from MCFM)
         sampleSet_["WZ"]              = FileSummary(fDir_ + MCloc + "WZ_TuneCUETP8M1_13TeV-pythia8.txt", "stopTreeMaker/AUX", 47.13,  lumi, 978512,  1.0,  kOrange+4);
         sampleSet_["ZZ"]              = FileSummary(fDir_ + MCloc + "ZZ_TuneCUETP8M1_13TeV-pythia8.txt", "stopTreeMaker/AUX", 16.523, lumi, 996944,  1.0,  kOrange+4);
 
-        // Tri-boson: negative weights! Still needs to be taken into account.
-        sampleSet_["WWZ"]             = FileSummary(fDir_ + MCloc + "WWZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt", "stopTreeMaker/AUX", 0.1651,  lumi, 250000,  1.0,  kOrange+2);
-        sampleSet_["WZZ"]             = FileSummary(fDir_ + MCloc + "WZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt", "stopTreeMaker/AUX", 0.05565, lumi, 250000,  1.0,  kOrange+2);
-        sampleSet_["ZZZ"]             = FileSummary(fDir_ + MCloc + "ZZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt", "stopTreeMaker/AUX", 0.01398, lumi, 250000,  1.0,  kOrange+2);
+        // Tri-boson: negative weights!
+        sampleSet_["WWZ"]             = FileSummary(fDir_ + MCloc + "WWZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt", "stopTreeMaker/AUX", 0.1651,  lumi, 235734 - 14266,  1.0,  kOrange+2);
+        sampleSet_["WZZ"]             = FileSummary(fDir_ + MCloc + "WZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt", "stopTreeMaker/AUX", 0.05565, lumi, 234584 - 15416,  1.0,  kOrange+2);
+        sampleSet_["ZZZ"]             = FileSummary(fDir_ + MCloc + "ZZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt", "stopTreeMaker/AUX", 0.01398, lumi, 231925 - 18075,  1.0,  kOrange+2);
 
         // --------
         // - data -

--- a/Tools/samples.cc
+++ b/Tools/samples.cc
@@ -52,47 +52,45 @@ namespace AnaSamples
         // TTbarInc has LO xsec on McM : 502.20 pb. The NNLO is 831.76 pb. The k-factor for ttbar is: kt = 831.76/502.20 ~ 1.656233
         sampleSet_["TTbarInc"]  = FileSummary(fDir_ + MCloc + "TTJets_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX", 831.76,  lumi, 11344206, 1.0, kGreen);
         // 1.61 * kt 
-        sampleSet_["TTbar_HT-600to800"]  = FileSummary(fDir_ + MCloc + "TTJets_HT-600to800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt",     "stopTreeMaker/AUX", 2.666535,  lumi, 5119009, 1.0, kGreen);
+        sampleSet_["TTbar_HT-600to800"]   = FileSummary(fDir_ + MCloc + "TTJets_HT-600to800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt",   "stopTreeMaker/AUX", 2.666535,    lumi, 5119009, 1.0, kGreen);
         // 0.663 * kt
-        sampleSet_["TTbar_HT-800to1200"]  = FileSummary(fDir_ + MCloc + "TTJets_HT-800to1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt",   "stopTreeMaker/AUX", 1.098082,  lumi, 3510897, 1.0, kGreen);
+        sampleSet_["TTbar_HT-800to1200"]  = FileSummary(fDir_ + MCloc + "TTJets_HT-800to1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt",  "stopTreeMaker/AUX", 1.098082,    lumi, 3510897, 1.0, kGreen);
         // 0.12 * kt
-        sampleSet_["TTbar_HT-1200to2500"]  = FileSummary(fDir_ + MCloc + "TTJets_HT-1200to2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX", 0.198748,  lumi, 1014678, 1.0, kGreen);
+        sampleSet_["TTbar_HT-1200to2500"] = FileSummary(fDir_ + MCloc + "TTJets_HT-1200to2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX", 0.198748,    lumi, 1014678, 1.0, kGreen);
         // 0.00143 * kt
-        sampleSet_["TTbar_HT-2500toInf"]  = FileSummary(fDir_ + MCloc + "TTJets_HT-2500toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt",   "stopTreeMaker/AUX", 0.002368413,  lumi, 507842, 1.0, kGreen);
+        sampleSet_["TTbar_HT-2500toInf"]  = FileSummary(fDir_ + MCloc + "TTJets_HT-2500toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt",  "stopTreeMaker/AUX", 0.002368413, lumi, 507842,  1.0, kGreen);
 
 
         // Calculated from PDG BRs'. Not from the kt * xSec in McM.
-        sampleSet_["TTbarDiLep"]  = FileSummary(fDir_ + MCloc + "TTJets_DiLept_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX", 831.76*TTbar_DiLept_BR,  lumi, 30498962, 1.0, kGreen);
-        sampleSet_["TTbarSingleLepT"]  = FileSummary(fDir_ + MCloc + "TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX", 831.76*0.5*TTbar_SingleLept_BR,  lumi, 60144642, 1.0, kGreen);
-        sampleSet_["TTbarSingleLepTbar"]  = FileSummary(fDir_ + MCloc + "TTJets_SingleLeptFromTbar_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX", 831.76*0.5*TTbar_SingleLept_BR,  lumi, 59816364, 1.0, kGreen);
+        sampleSet_["TTbarDiLep"]         = FileSummary(fDir_ + MCloc + "TTJets_DiLept_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt",             "stopTreeMaker/AUX", 831.76*TTbar_DiLept_BR,         lumi, 30498962, 1.0, kGreen);
+        sampleSet_["TTbarSingleLepT"]    = FileSummary(fDir_ + MCloc + "TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt",    "stopTreeMaker/AUX", 831.76*0.5*TTbar_SingleLept_BR, lumi, 60144642, 1.0, kGreen);
+        sampleSet_["TTbarSingleLepTbar"] = FileSummary(fDir_ + MCloc + "TTJets_SingleLeptFromTbar_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX", 831.76*0.5*TTbar_SingleLept_BR, lumi, 59816364, 1.0, kGreen);
 
-	// WJets to be updated
         // From https://twiki.cern.ch/twiki/bin/viewauth/CMS/SummaryTable1G25ns#W_jets, kw = 1.21
         sampleSet_["WJetsToLNu_HT_100to200"]  = FileSummary(fDir_ + MCloc + "WJetsToLNu_HT-100To200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX", 1345,  lumi, 10152718,  1.21, kMagenta+1);
         sampleSet_["WJetsToLNu_HT_200to400"]  = FileSummary(fDir_ + MCloc + "WJetsToLNu_HT-200To400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX", 359.7,  lumi, 5221599,  1.21, kMagenta+1);
         sampleSet_["WJetsToLNu_HT_400to600"]  = FileSummary(fDir_ + MCloc + "WJetsToLNu_HT-400To600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX", 48.91,  lumi, 1745914,  1.21, kMagenta+1);
         sampleSet_["WJetsToLNu_HT_600to800"]  = FileSummary(fDir_ + MCloc + "WJetsToLNu_HT-600To800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX", 12.05,  lumi, 4041997,  1.21, kMagenta+1);
-        sampleSet_["WJetsToLNu_HT_800to1200"]  = FileSummary(fDir_ + MCloc + "WJetsToLNu_HT-800To1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX", 5.501,  lumi, 1574633,  1.21, kMagenta+1);
-        sampleSet_["WJetsToLNu_HT_1200to2500"]  = FileSummary(fDir_ + MCloc + "WJetsToLNu_HT-1200To2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX", 1.329,  lumi, 210017,  1.21, kMagenta+1);
-        sampleSet_["WJetsToLNu_HT_2500toInf"]  = FileSummary(fDir_ + MCloc + "WJetsToLNu_HT-2500ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX", 0.03216,  lumi, 253036,  1.21, kMagenta+1);
+        sampleSet_["WJetsToLNu_HT_800to1200"]  = FileSummary(fDir_ + MCloc + "WJetsToLNu_HT-800To1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX",  5.501,   lumi, 1574633,  1.21, kMagenta+1);
+        sampleSet_["WJetsToLNu_HT_1200to2500"] = FileSummary(fDir_ + MCloc + "WJetsToLNu_HT-1200To2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX", 1.329,   lumi, 210017,   1.21, kMagenta+1);
+        sampleSet_["WJetsToLNu_HT_2500toInf"]  = FileSummary(fDir_ + MCloc + "WJetsToLNu_HT-2500ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX",  0.03216, lumi, 253036,   1.21, kMagenta+1);
         sampleSet_["WJetsToLNu_HT_600toInf"]  = FileSummary(fDir_ + MCloc + "WJetsToLNu_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX", 18.77,  lumi, 1039152,  1.21, kMagenta+1);
         
         //Z -> nunu
         // From https://twiki.cern.ch/twiki/bin/viewauth/CMS/SummaryTable1G25ns#DY_Z, kz = 1.23
-        sampleSet_["ZJetsToNuNu_HT_100to200"] = FileSummary(fDir_ + MCloc + "ZJetsToNuNu_HT-100To200_13TeV-madgraph.txt", "stopTreeMaker/AUX", 280.47, lumi, 5154824, 1.23,  kTeal+4);
-        sampleSet_["ZJetsToNuNu_HT_200to400"] = FileSummary(fDir_ + MCloc + "ZJetsToNuNu_HT-200To400_13TeV-madgraph.txt", "stopTreeMaker/AUX", 78.36,  lumi, 4998316, 1.23,  kTeal+4);
-        sampleSet_["ZJetsToNuNu_HT_400to600"] = FileSummary(fDir_ + MCloc + "ZJetsToNuNu_HT-400To600_13TeV-madgraph.txt", "stopTreeMaker/AUX", 10.94, lumi, 1018882, 1.23,  kTeal+4);
-        sampleSet_["ZJetsToNuNu_HT_600toInf"] = FileSummary(fDir_ + MCloc + "ZJetsToNuNu_HT-600ToInf_13TeV-madgraph.txt", "stopTreeMaker/AUX", 4.20,  lumi, 1008333, 1.23,  kTeal+4);
+        sampleSet_["ZJetsToNuNu_HT_100to200"] = FileSummary(fDir_ + MCloc + "ZJetsToNuNu_HT-100To200_13TeV-madgraph.txt", "stopTreeMaker/AUX", 280.35, lumi, 5154824, 1.23,  kTeal+4);
+        sampleSet_["ZJetsToNuNu_HT_200to400"] = FileSummary(fDir_ + MCloc + "ZJetsToNuNu_HT-200To400_13TeV-madgraph.txt", "stopTreeMaker/AUX", 77.67,  lumi, 4998316, 1.23,  kTeal+4);
+        sampleSet_["ZJetsToNuNu_HT_400to600"] = FileSummary(fDir_ + MCloc + "ZJetsToNuNu_HT-400To600_13TeV-madgraph.txt", "stopTreeMaker/AUX", 10.73,  lumi, 1018882, 1.23,  kTeal+4);
+        sampleSet_["ZJetsToNuNu_HT_600toInf"] = FileSummary(fDir_ + MCloc + "ZJetsToNuNu_HT-600ToInf_13TeV-madgraph.txt", "stopTreeMaker/AUX", 4.116,  lumi, 1008333, 1.23,  kTeal+4);
 
         //DY->ll
         // kz = 1.23
-        sampleSet_["DYJetsToLL_HT_100to200"]  = FileSummary(fDir_ + MCloc + "DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX", 139.4,  lumi, 2725655, 1.23,  kYellow-7);
-        sampleSet_["DYJetsToLL_HT_200to400"]  = FileSummary(fDir_ + MCloc + "DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX", 42.75,  lumi, 973937, 1.23,  kYellow-7);
-        sampleSet_["DYJetsToLL_HT_400to600"]  = FileSummary(fDir_ + MCloc + "DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX", 5.497,  lumi, 1067758, 1.23,  kYellow-7);
-        sampleSet_["DYJetsToLL_HT_600toInf"]  = FileSummary(fDir_ + MCloc + "DYJetsToLL_M-50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX", 2.21,  lumi, 998912, 1.23,  kYellow-7);
-
+        sampleSet_["DYJetsToLL_HT_100to200"] = FileSummary(fDir_ + MCloc + "DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX", 147.4, lumi, 2725655, 1.23,  kYellow-7);
+        sampleSet_["DYJetsToLL_HT_200to400"] = FileSummary(fDir_ + MCloc + "DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX", 40.99, lumi, 973937,  1.23,  kYellow-7);
+        sampleSet_["DYJetsToLL_HT_400to600"] = FileSummary(fDir_ + MCloc + "DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX", 5.678, lumi, 1067758, 1.23,  kYellow-7);
+        sampleSet_["DYJetsToLL_HT_600toInf"] = FileSummary(fDir_ + MCloc + "DYJetsToLL_M-50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt", "stopTreeMaker/AUX", 2.198, lumi, 998912,  1.23,  kYellow-7);
         // NNLO
-//        sampleSet_["IncDYSampleSet"]          = FileSummary(fDir_ + MCloc + "DYJetsToLL_M-50_13TeV-madgraph-pythia8.txt", "stopTreeMaker/AUX", 6025.2,  lumi, 2829164, 1.0,  kYellow-4);
+        sampleSet_["DYJetsToLL_Inc"]         = FileSummary(fDir_ + MCloc + "DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8.txt",             "stopTreeMaker/AUX", 6025.2, lumi, 9042031, 1.0,  kYellow-7);
 
         //QCD
         // Ref. https://twiki.cern.ch/twiki/bin/viewauth/CMS/SummaryTable1G25ns#QCD. But numbers are from McM.
@@ -130,20 +128,31 @@ namespace AnaSamples
 
         // NLO --> negative weights!
         // (sign of gen weight) * (lumi*xsec)/(effective number of events): effective number of events = N(evt) with positive weight - N(evt) with negative weight
-        sampleSet_["TTZToLLNuNu"]               = FileSummary(fDir_ + MCloc + "TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt", "stopTreeMaker/AUX", 0.2529, lumi, 291495 - 106505,  1.0,  kOrange+2);
-        sampleSet_["TTZToQQ"]                   = FileSummary(fDir_ + MCloc + "TTZToQQ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt", "stopTreeMaker/AUX", 0.5297, lumi, 550599 - 199201,  1.0,  kOrange+2);
+        sampleSet_["TTZToLLNuNu"]         = FileSummary(fDir_ + MCloc + "TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt", "stopTreeMaker/AUX", 0.2529, lumi, 291495 - 106505,  1.0,  kOrange+2);
+        sampleSet_["TTZToQQ"]             = FileSummary(fDir_ + MCloc + "TTZToQQ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt", "stopTreeMaker/AUX", 0.5297, lumi, 550599 - 199201,  1.0,  kOrange+2);
 
         // NLO --> negative weights!
-        sampleSet_["TTWJetsToLNu"]              = FileSummary(fDir_ + MCloc + "TTWJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8.txt", "stopTreeMaker/AUX", 0.2043, lumi, 191379 - 61529,  1.0,  kSpring+2);
-        sampleSet_["TTWJetsToQQ"]               = FileSummary(fDir_ + MCloc + "TTWJetsToQQ_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8.txt", "stopTreeMaker/AUX", 0.4062, lumi, 632147 - 201817,  1.0,  kSpring+2);
+        sampleSet_["TTWJetsToLNu"]        = FileSummary(fDir_ + MCloc + "TTWJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8.txt", "stopTreeMaker/AUX", 0.2043, lumi, 191379 - 61529,   1.0,  kSpring+2);
+        sampleSet_["TTWJetsToQQ"]         = FileSummary(fDir_ + MCloc + "TTWJetsToQQ_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8.txt",  "stopTreeMaker/AUX", 0.4062, lumi, 632147 - 201817,  1.0,  kSpring+2);
 
-        // ttH --> ??
+        // NLO --> negative weights! Still need to taken them into account
+        sampleSet_["TTGJets"]             = FileSummary(fDir_ + MCloc + "TTGJets_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8.txt", "stopTreeMaker/AUX", 3.697, lumi, 4832230,  1.0,  kSpring+2);
+
+        // ttH --> negative weights! Still need to take them into account
+	sampleSet_["ttHJetTobb"]     = FileSummary(fDir_ + MCloc + "ttHJetTobb_M125_13TeV_amcatnloFXFX_madspin_pythia8.txt",             "stopTreeMaker/AUX", 0.2934,  lumi, 1612604,  1.0,  kOrange+2);
+	sampleSet_["ttHJetToNonbb"]  = FileSummary(fDir_ + MCloc + "ttHJetToNonbb_M125_13TeV_amcatnloFXFX_madspin_pythia8_mWCutfix.txt", "stopTreeMaker/AUX", 0.2151,  lumi, 8025223,  1.0,  kOrange+2);
         
         // Di-boson?
+	// Ref. https://indico.cern.ch/event/439995/session/0/contribution/6/attachments/1143460/1638648/diboson_final.pdf (NNLO is given)
+        sampleSet_["WW"]              = FileSummary(fDir_ + MCloc + "WW_TuneCUETP8M1_13TeV-pythia8.txt", "stopTreeMaker/AUX", 115.0,  lumi, 993640,  1.0,  kOrange+4); 
+	// Ref. https://twiki.cern.ch/twiki/bin/viewauth/CMS/SummaryTable1G25ns (NLO from MCFM)
+        sampleSet_["WZ"]              = FileSummary(fDir_ + MCloc + "WZ_TuneCUETP8M1_13TeV-pythia8.txt", "stopTreeMaker/AUX", 47.13,  lumi, 978512,  1.0,  kOrange+4);
+        sampleSet_["ZZ"]              = FileSummary(fDir_ + MCloc + "ZZ_TuneCUETP8M1_13TeV-pythia8.txt", "stopTreeMaker/AUX", 16.523, lumi, 996944,  1.0,  kOrange+4);
 
-        // Tri-boson
-        sampleSet_["WWZ"]             = FileSummary(fDir_ + MCloc + "WWZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt", "stopTreeMaker/AUX", 0.1651, lumi, 250000,  1.0,  kOrange+2);
+        // Tri-boson: negative weights! Still needs to be taken into account.
+        sampleSet_["WWZ"]             = FileSummary(fDir_ + MCloc + "WWZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt", "stopTreeMaker/AUX", 0.1651,  lumi, 250000,  1.0,  kOrange+2);
         sampleSet_["WZZ"]             = FileSummary(fDir_ + MCloc + "WZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt", "stopTreeMaker/AUX", 0.05565, lumi, 250000,  1.0,  kOrange+2);
+        sampleSet_["ZZZ"]             = FileSummary(fDir_ + MCloc + "ZZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8.txt", "stopTreeMaker/AUX", 0.01398, lumi, 250000,  1.0,  kOrange+2);
 
         // --------
         // - data -
@@ -210,7 +219,7 @@ namespace AnaSamples
 
         addSampleSet(samples, "ZJetsToNuNu", {"ZJetsToNuNu_HT_600toInf", "ZJetsToNuNu_HT_400to600", "ZJetsToNuNu_HT_200to400", "ZJetsToNuNu_HT_100to200"});
         addSampleSet(samples, "DYJetsToLL", {"DYJetsToLL_HT_600toInf", "DYJetsToLL_HT_400to600", "DYJetsToLL_HT_200to400", "DYJetsToLL_HT_100to200"});
-        addSampleSet(samples, "IncDY", {"DYJetsToLL"});
+        addSampleSet(samples, "IncDY", {"DYJetsToLL_Inc"});
 
         addSampleSet(samples, "QCD", {"QCD_HT2000toInf", "QCD_HT1500to2000", "QCD_HT1000to1500", "QCD_HT700to1000", "QCD_HT500to700", "QCD_HT300to500", "QCD_HT200to300", "QCD_HT100to200"});
 
@@ -219,10 +228,17 @@ namespace AnaSamples
         addSampleSet(samples, "TTZ", {"TTZToLLNuNu", "TTZToQQ"});
         addSampleSet(samples, "TTW", {"TTWJetsToLNu", "TTWJetsToQQ"});
 
+	addSampleSet(samples, "ttHJetTobb", {"ttHJetTobb"});
+	addSampleSet(samples, "ttHJetToNonbb", {"ttHJetToNonbb"});
+	addSampleSet(samples, "ttH", {"ttHJetTobb", "ttHJetToNonbb"});
+
         addSampleSet(samples, "WWZ", {"WWZ"});
         addSampleSet(samples, "WZZ", {"WZZ"});
+        addSampleSet(samples, "ZZZ", {"ZZZ"});
 
-	addSampleSet(samples, "Rare", {"TTWJetsToLNu", "TTWJetsToQQ", "WWZ", "WZZ"});
+        addSampleSet(samples, "Diboson", {"WW","WZ","ZZ"});
+
+	addSampleSet(samples, "Rare", {"TTWJetsToLNu", "TTWJetsToQQ", "TTGJets", "WWZ", "WZZ", "ZZZ", "ttHJetTobb", "ttHJetToNonbb"});
 
         addSampleSet(samples, "Data_SingleMuon", {"Data_SingleMuon_2015C", "Data_SingleMuon_2015D_05Oct2015", "Data_SingleMuon_2015D_PromptReco"});
 


### PR DESCRIPTION
Update to samples.cc:
- update cross sections of DYJetsToLL HT binned and ZJetsToNuNu HT binned to more accurate values (from standard twiki)
- Add Inclusive DY, Diboson, ZZZ, ttH and TTG samples

Update to nEvts.C:
- Add flag "-w" to active the computation of number of positive and negative weights
- Former functionality still works as it was
