### PR TITLE
Add searchbin lines for plots that are not on a logscale

### DIFF
--- a/Tools/searchBins.h
+++ b/Tools/searchBins.h
@@ -358,7 +358,7 @@ void print_searchBins_latex(const std::vector<double>& prediction, const std::ve
 }
 
 // Function to draw the signal bin definition
-void drawSBregionDef(const double ymin_Yields = 0.05, const double ymax_Yields = 500.){
+void drawSBregionDef(const double ymin_Yields = 0.05, const double ymax_Yields = 500., const bool logscale=true){
 
    const double adjHalfBin = 0.5;
    //-----------------------------------------------------------
@@ -367,30 +367,49 @@ void drawSBregionDef(const double ymin_Yields = 0.05, const double ymax_Yields =
    // Ntop separation lines
    TLine *tl_ntop = new TLine();
    tl_ntop->SetLineStyle(2);
-   tl_ntop->DrawLine(23.5 + adjHalfBin,ymin_Yields,23.5 + adjHalfBin,ymax_Yields);
-   tl_ntop->DrawLine(41.5 + adjHalfBin,ymin_Yields,41.5 + adjHalfBin,ymax_Yields);
+       tl_ntop->DrawLine(23.5 + adjHalfBin,ymin_Yields,23.5 + adjHalfBin,ymax_Yields);
+       tl_ntop->DrawLine(41.5 + adjHalfBin,ymin_Yields,41.5 + adjHalfBin,ymax_Yields);
 
    // Ntop labels
    TLatex * ttext_ntop = new TLatex();
    ttext_ntop->SetTextFont(42);
    ttext_ntop->SetTextSize(0.06);
    ttext_ntop->SetTextAlign(22);
-   ttext_ntop->DrawLatex(11.5 + adjHalfBin, ymax_Yields/1.8 ,"N_{top} = 1");
-   ttext_ntop->DrawLatex(35.5 + adjHalfBin, ymax_Yields/35. ,"N_{top} = 2");
-   ttext_ntop->SetTextAngle(90.);
-   ttext_ntop->DrawLatex(43. + adjHalfBin, ymax_Yields/15. ,"N_{top} #geq 3");
+   if(logscale)
+   {
+       ttext_ntop->DrawLatex(11.5 + adjHalfBin, ymax_Yields/1.8 ,"N_{top} = 1");
+       ttext_ntop->DrawLatex(35.5 + adjHalfBin, ymax_Yields/35. ,"N_{top} = 2");
+       ttext_ntop->SetTextAngle(90.);
+       ttext_ntop->DrawLatex(43. + adjHalfBin, ymax_Yields/15. ,"N_{top} #geq 3");
+   } else
+   {
+       ttext_ntop->DrawLatex(11.5 + adjHalfBin, ymax_Yields*0.92 ,"N_{top} = 1");
+       ttext_ntop->DrawLatex(35.5 + adjHalfBin, ymax_Yields*0.92 ,"N_{top} = 2");
+       ttext_ntop->SetTextAngle(90.);
+       ttext_ntop->DrawLatex(43. + adjHalfBin, ymax_Yields*0.85 ,"N_{top} #geq 3");
+   }
 
    // Nb separation lines
    TLine *tl_nb = new TLine();
    tl_nb->SetLineStyle(3);
    tl_nb->SetLineColor(32);
-   tl_nb->DrawLine(10.5 + adjHalfBin,ymin_Yields,10.5 + adjHalfBin,ymax_Yields/4.);
-   tl_nb->DrawLine(20.5 + adjHalfBin,ymin_Yields,20.5 + adjHalfBin,ymax_Yields/4.);
-   tl_nb->DrawLine(31.5 + adjHalfBin,ymin_Yields,31.5 + adjHalfBin,ymax_Yields/40.);
-   tl_nb->DrawLine(39.5 + adjHalfBin,ymin_Yields,39.5 + adjHalfBin,ymax_Yields/40.);
-   tl_nb->DrawLine(42.5 + adjHalfBin,ymin_Yields,42.5 + adjHalfBin,ymax_Yields/40.);
-   tl_nb->DrawLine(43.5 + adjHalfBin,ymin_Yields,43.5 + adjHalfBin,ymax_Yields/40.);
-
+   if(logscale)
+   {
+       tl_nb->DrawLine(10.5 + adjHalfBin,ymin_Yields,10.5 + adjHalfBin,ymax_Yields/4.);
+       tl_nb->DrawLine(20.5 + adjHalfBin,ymin_Yields,20.5 + adjHalfBin,ymax_Yields/4.);
+       tl_nb->DrawLine(31.5 + adjHalfBin,ymin_Yields,31.5 + adjHalfBin,ymax_Yields/40.);
+       tl_nb->DrawLine(39.5 + adjHalfBin,ymin_Yields,39.5 + adjHalfBin,ymax_Yields/40.);
+       tl_nb->DrawLine(42.5 + adjHalfBin,ymin_Yields,42.5 + adjHalfBin,ymax_Yields/40.);
+       tl_nb->DrawLine(43.5 + adjHalfBin,ymin_Yields,43.5 + adjHalfBin,ymax_Yields/40.);
+   } else
+   {
+       tl_nb->DrawLine(10.5 + adjHalfBin,ymin_Yields,10.5 + adjHalfBin,ymax_Yields*0.8);
+       tl_nb->DrawLine(20.5 + adjHalfBin,ymin_Yields,20.5 + adjHalfBin,ymax_Yields*0.8);
+       tl_nb->DrawLine(31.5 + adjHalfBin,ymin_Yields,31.5 + adjHalfBin,ymax_Yields*0.8);
+       tl_nb->DrawLine(39.5 + adjHalfBin,ymin_Yields,39.5 + adjHalfBin,ymax_Yields*0.8);
+       tl_nb->DrawLine(42.5 + adjHalfBin,ymin_Yields,42.5 + adjHalfBin,ymax_Yields*0.8);
+       tl_nb->DrawLine(43.5 + adjHalfBin,ymin_Yields,43.5 + adjHalfBin,ymax_Yields*0.8);
+   }
    // Nb labels
    TLatex * ttext2 = new TLatex();
    ttext2->SetTextFont(42);
@@ -399,25 +418,46 @@ void drawSBregionDef(const double ymin_Yields = 0.05, const double ymax_Yields =
    ttext2->SetTextAlign(22);
    ttext2->Draw();
 
-   ttext2->DrawLatex( 4.5 + adjHalfBin, ymax_Yields/3., "N_{b} = 1");
-   ttext2->DrawLatex(14.5 + adjHalfBin, ymax_Yields/3., "N_{b} = 2");
-   ttext2->SetTextAngle(90.);
-   ttext2->DrawLatex(21.5 + adjHalfBin, ymax_Yields/3. , "N_{b} #geq 3");
-
+   if(logscale)
+   {
+       ttext2->DrawLatex( 4.5 + adjHalfBin, ymax_Yields/3., "N_{b} = 1");
+       ttext2->DrawLatex(14.5 + adjHalfBin, ymax_Yields/3., "N_{b} = 2");
+       ttext2->SetTextAngle(90.);
+       ttext2->DrawLatex(21.5 + adjHalfBin, ymax_Yields/3. , "N_{b} #geq 3");
+   } else
+   {
+       ttext2->DrawLatex( 4.5 + adjHalfBin, ymax_Yields*0.8, "N_{b} = 1");
+       ttext2->DrawLatex(14.5 + adjHalfBin, ymax_Yields*0.8, "N_{b} = 2");
+       ttext2->SetTextAngle(90.);
+       ttext2->DrawLatex(21.5 + adjHalfBin + 0.5, ymax_Yields*0.8, "N_{b} #geq 3");
+   }
    // MT2 separation lines
    TLine *tl_mt2 = new TLine();
    tl_mt2->SetLineStyle(4);
    tl_mt2->SetLineColor(49);
-   tl_mt2->DrawLine(3.5 + adjHalfBin,ymin_Yields,3.5 + adjHalfBin,ymax_Yields/20.);
-   tl_mt2->DrawLine(7.5 + adjHalfBin,ymin_Yields,7.5 + adjHalfBin,ymax_Yields/20.);
-   tl_mt2->DrawLine(14.5 + adjHalfBin,ymin_Yields,14.5 + adjHalfBin,ymax_Yields/20.);
-   tl_mt2->DrawLine(18.5 + adjHalfBin,ymin_Yields,18.5 + adjHalfBin,ymax_Yields/20.);
-
-   tl_mt2->DrawLine(26.5 + adjHalfBin,ymin_Yields,26.5 + adjHalfBin,ymax_Yields/80.);
-   tl_mt2->DrawLine(29.5 + adjHalfBin,ymin_Yields,29.5 + adjHalfBin,ymax_Yields/80.);
-   tl_mt2->DrawLine(34.5 + adjHalfBin,ymin_Yields,34.5 + adjHalfBin,ymax_Yields/80.);
-   tl_mt2->DrawLine(37.5 + adjHalfBin,ymin_Yields,37.5 + adjHalfBin,ymax_Yields/80.);
-
+   if(logscale)
+   {
+       tl_mt2->DrawLine(3.5 + adjHalfBin,ymin_Yields,3.5 + adjHalfBin,ymax_Yields/20.);
+       tl_mt2->DrawLine(7.5 + adjHalfBin,ymin_Yields,7.5 + adjHalfBin,ymax_Yields/20.);
+       tl_mt2->DrawLine(14.5 + adjHalfBin,ymin_Yields,14.5 + adjHalfBin,ymax_Yields/20.);
+       tl_mt2->DrawLine(18.5 + adjHalfBin,ymin_Yields,18.5 + adjHalfBin,ymax_Yields/20.);
+       
+       tl_mt2->DrawLine(26.5 + adjHalfBin,ymin_Yields,26.5 + adjHalfBin,ymax_Yields/80.);
+       tl_mt2->DrawLine(29.5 + adjHalfBin,ymin_Yields,29.5 + adjHalfBin,ymax_Yields/80.);
+       tl_mt2->DrawLine(34.5 + adjHalfBin,ymin_Yields,34.5 + adjHalfBin,ymax_Yields/80.);
+       tl_mt2->DrawLine(37.5 + adjHalfBin,ymin_Yields,37.5 + adjHalfBin,ymax_Yields/80.);
+   } else
+   {
+       tl_mt2->DrawLine(3.5 + adjHalfBin,ymin_Yields,3.5 + adjHalfBin,ymax_Yields*0.6);
+       tl_mt2->DrawLine(7.5 + adjHalfBin,ymin_Yields,7.5 + adjHalfBin,ymax_Yields*0.6);
+       tl_mt2->DrawLine(14.5 + adjHalfBin,ymin_Yields,14.5 + adjHalfBin,ymax_Yields*0.6);
+       tl_mt2->DrawLine(18.5 + adjHalfBin,ymin_Yields,18.5 + adjHalfBin,ymax_Yields*0.6);
+       
+       tl_mt2->DrawLine(26.5 + adjHalfBin,ymin_Yields,26.5 + adjHalfBin,ymax_Yields*0.6);
+       tl_mt2->DrawLine(29.5 + adjHalfBin,ymin_Yields,29.5 + adjHalfBin,ymax_Yields*0.6);
+       tl_mt2->DrawLine(34.5 + adjHalfBin,ymin_Yields,34.5 + adjHalfBin,ymax_Yields*0.6);
+       tl_mt2->DrawLine(37.5 + adjHalfBin,ymin_Yields,37.5 + adjHalfBin,ymax_Yields*0.6);
+   }
    // MT2 labels
    TLatex * ttextmt2 = new TLatex();
    ttextmt2->SetTextFont(42);
@@ -425,9 +465,17 @@ void drawSBregionDef(const double ymin_Yields = 0.05, const double ymax_Yields =
    ttextmt2->SetTextSize(0.02);
    ttextmt2->SetTextAlign(22);
    ttextmt2->SetTextAngle(90);
-   ttextmt2->DrawLatex( 1.5 + adjHalfBin, ymax_Yields/10. , "M_{T2}=[200,300]");
-   ttextmt2->DrawLatex( 5.0 + adjHalfBin, ymax_Yields/10. , "M_{T2}=[300,400]");
-   ttextmt2->DrawLatex(8.5 + adjHalfBin, ymax_Yields/10. , "M_{T2}#geq400");
+   if(logscale)
+   {
+       ttextmt2->DrawLatex( 1.5 + adjHalfBin, ymax_Yields/10. , "M_{T2}=[200,300]");
+       ttextmt2->DrawLatex( 5.0 + adjHalfBin, ymax_Yields/10. , "M_{T2}=[300,400]");
+       ttextmt2->DrawLatex(8.5 + adjHalfBin, ymax_Yields/10. , "M_{T2}#geq400");
+   } else
+   {
+       ttextmt2->DrawLatex( 1.5 + adjHalfBin, ymax_Yields*0.55 , "M_{T2}=[200,300]");
+       ttextmt2->DrawLatex( 5.0 + adjHalfBin, ymax_Yields*0.55 , "M_{T2}=[300,400]");
+       ttextmt2->DrawLatex(8.5 + adjHalfBin, ymax_Yields*0.55 , "M_{T2}#geq400");
+   }
    //-----------------------------------------------------------
 
 }


### PR DESCRIPTION
Now takes an argument to turn off the logscale. Defaults to true so that the original behavior is kept.
