### PR TITLE
Readded filling of muon collection used in top projection

### DIFF
--- a/SkimsAUX/plugins/prodMuons.cc
+++ b/SkimsAUX/plugins/prodMuons.cc
@@ -193,7 +193,7 @@ bool prodMuons::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
       }
 
       //add muons to clean from jets 
-   //   if(isMediumID && miniIso < maxMuMiniIso_ && m->pt() > minMuPtForMuon2Clean_) mu2Clean->push_back(*m);
+      if(isMediumID && miniIso < maxMuMiniIso_ && m->pt() > minMuPtForMuon2Clean_) mu2Clean->push_back(*m);
     }
   }
     


### PR DESCRIPTION
This is the cause of all the Znunu weirdness 

We will need to rerun all Znunu related backgrounds and data Ntuple production ASAP.  This means everything except than HTMHT data and W/QCD bg MC
