### PR TITLE
Fix to BTagCorrector.h to avoid segfault

### DIFF
--- a/Tools/BTagCorrector.h
+++ b/Tools/BTagCorrector.h
@@ -64,11 +64,9 @@ BTagCorrector(std::string file = "TTbarNoHad_bTagEff.root", std::string CSVFileP
 	    TH2F *d_eff_c = (TH2F*)file->Get(("d_eff_c_" + suffix).c_str());
 	    TH2F *d_eff_udsg = (TH2F*)file->Get(("d_eff_udsg_" + suffix).c_str());
 
-	    
 	    h_eff_b->Divide(d_eff_b);
 	    h_eff_c->Divide(d_eff_c);
 	    h_eff_udsg->Divide(d_eff_udsg);
-
 
         }
         else
@@ -81,11 +79,11 @@ BTagCorrector(std::string file = "TTbarNoHad_bTagEff.root", std::string CSVFileP
 	    TH2F *d_eff_c = (TH2F*)file->Get("d_eff_c");
             TH2F *d_eff_udsg = (TH2F*)file->Get("d_eff_udsg");
 
-            h_eff_b->Divide(d_eff_b);
-            h_eff_c->Divide(d_eff_c);
-            h_eff_udsg->Divide(d_eff_udsg);
-
-
+	    if(h_eff_b){
+	      h_eff_b->Divide(d_eff_b);
+	      h_eff_c->Divide(d_eff_c);
+	      h_eff_udsg->Divide(d_eff_udsg);
+	    }
         }
     }
     void resetEffs(std::string suffix)

--- a/Tools/bTagEfficiencyCalc.C
+++ b/Tools/bTagEfficiencyCalc.C
@@ -70,6 +70,7 @@ int main(int argc, char* argv[])
 
     TFile *infile = nullptr;
     infile = new TFile(samplesT+"_bTagEff"+nmStrT+"_"+std::to_string(startFile)+".root", "RECREATE");
+    //infile = new TFile("bTagEff"+samplesT+"_"+nmStrT+"_"+std::to_string(startFile)+".root", "RECREATE");
 
     /*************************************************************/      
     //Declare efficiency histograms. n-> numerator d-> denominator
@@ -83,6 +84,13 @@ int main(int argc, char* argv[])
     TH2* d_eff_b =    new TH2D("d_eff_b", "bTag_Efficiency"+nmStrT, nPtBins, ptBins, nEtaBins, etaBins);
     TH2* d_eff_c =    new TH2D("d_eff_c", "cTag_Efficiency"+nmStrT, nPtBins, ptBins, nEtaBins, etaBins);
     TH2* d_eff_udsg = new TH2D("d_eff_udsg", "udsgTag_Efficiency"+nmStrT, nPtBins, ptBins, nEtaBins, etaBins);
+
+    // TH2* n_eff_b =    new TH2D("n_eff_b_"+samplesT, "bTag_Efficiency"+samplesT, nPtBins, ptBins, nEtaBins, etaBins);
+    // TH2* n_eff_c =    new TH2D("n_eff_c_"+samplesT, "cTag_Efficiency"+samplesT, nPtBins, ptBins, nEtaBins, etaBins);
+    // TH2* n_eff_udsg = new TH2D("n_eff_udsg_"+samplesT, "udsgTag_Efficiency"+samplesT, nPtBins, ptBins, nEtaBins, etaBins);
+    // TH2* d_eff_b =    new TH2D("d_eff_b_"+samplesT, "bTag_Efficiency"+samplesT, nPtBins, ptBins, nEtaBins, etaBins);
+    // TH2* d_eff_c =    new TH2D("d_eff_c_"+samplesT, "cTag_Efficiency"+samplesT, nPtBins, ptBins, nEtaBins, etaBins);
+    // TH2* d_eff_udsg = new TH2D("d_eff_udsg_"+samplesT, "udsgTag_Efficiency"+samplesT, nPtBins, ptBins, nEtaBins, etaBins);
       
     n_eff_b->GetXaxis()->SetTitle("p_{T} [GeV]");
     n_eff_b->GetYaxis()->SetTitle("#eta");


### PR DESCRIPTION
- add protection against segfaults
- add some lines (now commented) to script to create btag efficiency files in case you want to run over all MC samples and combine into one file
