### PR TITLE
QGL database from v1 to v2b, and add JetID for lepton veto

### DIFF
--- a/SkimsAUX/plugins/prodJetIDEventFilter.cc
+++ b/SkimsAUX/plugins/prodJetIDEventFilter.cc
@@ -16,13 +16,16 @@ class prodJetIDEventFilter : public edm::EDFilter
  private:
   virtual bool filter(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
   edm::EDGetTokenT<edm::View<pat::Jet> > theJetToken_;
-  // Default are for Jet ID, loose and tight (https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID#Recommendations_for_13_TeV_data)
+  //Default are for Jet ID, loose and tight (https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID#Recommendations_for_13_TeV_data)
   const double minJetPt_, maxJetEta_;
   //Eta smaller than 2.7
   const double maxNeutHadF_Loose_EtaLe27_, maxNeutEmF_Loose_EtaLe27_; 
   const int minNumCon_Loose_EtaLe27_; 
   const double maxNeutHadF_Tight_EtaLe27_, maxNeutEmF_Tight_EtaLe27_;
   const int minNumCon_Tight_EtaLe27_;
+  const double maxNeutHadF_TightLepVeto_EtaLe27_, maxNeutEmF_TightLepVeto_EtaLe27_;
+  const int minNumCon_TightLepVeto_EtaLe27_;
+  const double maxMuF_TightLepVeto_EtaLe27_;
   //Additional Eta smaller than 2.4
   const double minChargHadF_Loose_EtaLe24_;  
   const int minChargMulti_Loose_EtaLe24_;
@@ -30,6 +33,9 @@ class prodJetIDEventFilter : public edm::EDFilter
   const double minChargHadF_Tight_EtaLe24_;
   const int minChargMulti_Tight_EtaLe24_;
   const double maxChargEmF_Tight_EtaLe24_;
+  const double minChargHadF_TightLepVeto_EtaLe24_;
+  const int minChargMulti_TightLepVeto_EtaLe24_;
+  const double maxChargEmF_TightLepVeto_EtaLe24_;
   //Eta 2.7 to 3.0
   const double maxNeutEmF_Loose_Eta27to30_; 
   const int minNumNeutPart_Loose_Eta27to30_;
@@ -59,6 +65,10 @@ prodJetIDEventFilter::prodJetIDEventFilter(const edm::ParameterSet & iConfig)
    , maxNeutHadF_Tight_EtaLe27_ (iConfig.getUntrackedParameter<double>("MaxNeutralHadFrac_Tight_EtaLe27", 0.90) )
    , maxNeutEmF_Tight_EtaLe27_  (iConfig.getUntrackedParameter<double>("MaxNeutralEMFrac_Tight_EtaLe27", 0.90) )
    , minNumCon_Tight_EtaLe27_ (iConfig.getUntrackedParameter<int>("MinNumberOfConstituents_Tight_EtaLe27", 1) )
+   , maxNeutHadF_TightLepVeto_EtaLe27_ (iConfig.getUntrackedParameter<double>("MaxNeutralHadFrac_TightLepVeto_EtaLe27", 0.90) )
+   , maxNeutEmF_TightLepVeto_EtaLe27_  (iConfig.getUntrackedParameter<double>("MaxNeutralEMFrac_TightLepVeto_EtaLe27", 0.90) )
+   , minNumCon_TightLepVeto_EtaLe27_ (iConfig.getUntrackedParameter<int>("MinNumberOfConstituents_TightLepVeto_EtaLe27", 1) )
+   , maxMuF_TightLepVeto_EtaLe27_ (iConfig.getUntrackedParameter<double>("maxMuF_TightLepVeto_EtaLe27", 0.80) )
    //Additional cut for Eta smaller than 2.4, tracker ??
    , minChargHadF_Loose_EtaLe24_ (iConfig.getUntrackedParameter<double>("MinChargedHadFrac_Loose_EtaLe24", 0) )
    , minChargMulti_Loose_EtaLe24_ (iConfig.getUntrackedParameter<int>("MinChargedMultiplicity_Loose_EtaLe24", 0) )
@@ -66,6 +76,9 @@ prodJetIDEventFilter::prodJetIDEventFilter(const edm::ParameterSet & iConfig)
    , minChargHadF_Tight_EtaLe24_ (iConfig.getUntrackedParameter<double>("MinChargedHadFrac_Tight_EtaLe24", 0) )
    , minChargMulti_Tight_EtaLe24_ (iConfig.getUntrackedParameter<int>("MinChargedMultiplicity_Tight_EtaLe24", 0) )
    , maxChargEmF_Tight_EtaLe24_ (iConfig.getUntrackedParameter<double>("MaxChargedEMFrac_Tight_EtaLe24", 0.99) )
+   , minChargHadF_TightLepVeto_EtaLe24_ (iConfig.getUntrackedParameter<double>("MinChargedHadFrac_TightLepVeto_EtaLe24", 0) )
+   , minChargMulti_TightLepVeto_EtaLe24_ (iConfig.getUntrackedParameter<int>("MinChargedMultiplicity_TightLepVeto_EtaLe24", 0) )
+   , maxChargEmF_TightLepVeto_EtaLe24_ (iConfig.getUntrackedParameter<double>("MaxChargedEMFrac_TightLepVeto_EtaLe24", 0.90) )
    //Eta 2.7 to 3.0
    , maxNeutEmF_Loose_Eta27to30_ (iConfig.getUntrackedParameter<double>("MaxNeutralEMFracHF_Loose_Eta27to30", 0.90) )
    , minNumNeutPart_Loose_Eta27to30_ (iConfig.getUntrackedParameter<int>("MinNumberOfNeutralParticles_Loose_Eta27to30", 2) )
@@ -82,6 +95,7 @@ prodJetIDEventFilter::prodJetIDEventFilter(const edm::ParameterSet & iConfig)
 {
   produces<bool>("looseJetID");
   produces<bool>("tightJetID");
+  produces<bool>("tightlepvetoJetID");
 }
 
 
@@ -96,7 +110,7 @@ bool prodJetIDEventFilter::filter(edm::Event & iEvent, const edm::EventSetup & i
   edm::Handle<edm::View<pat::Jet>> jets;
   iEvent.getByToken(theJetToken_, jets);
 
-  bool goodJetID = true, goodJetIDtight = true;
+  bool goodJetID = true, goodJetIDtight = true, goodJetIDtightlepveto = true;
   int jetIdx =-1;
 
   for (edm::View<pat::Jet>::const_iterator j = jets->begin(); j != jets->end(); ++j)
@@ -115,7 +129,7 @@ bool prodJetIDEventFilter::filter(edm::Event & iEvent, const edm::EventSetup & i
         double NHF = j->neutralHadronEnergyFraction();
         double NEMF = j->neutralEmEnergyFraction();
         int NumConst = j->chargedMultiplicity() + j->neutralMultiplicity();
-        //double MUF = j->muonEnergyFraction();
+        double MUF = j->muonEnergyFraction();
 
         double CHF = j->chargedHadronEnergyFraction();
         int CHM = j->chargedMultiplicity();
@@ -123,36 +137,42 @@ bool prodJetIDEventFilter::filter(edm::Event & iEvent, const edm::EventSetup & i
 
         int NumNeutralParticle = j->neutralMultiplicity();
 
-        bool perlooseJetID = true, pertightJetID = true;
+        bool perlooseJetID = true, pertightJetID = true, pertightlepvetoJetID = true;
         if( std::abs(eta) <= 2.7 )
         {
           perlooseJetID = NHF<maxNeutHadF_Loose_EtaLe27_ && NEMF<maxNeutEmF_Loose_EtaLe27_ && NumConst>minNumCon_Loose_EtaLe27_;
           pertightJetID = NHF<maxNeutHadF_Tight_EtaLe27_ && NEMF<maxNeutEmF_Tight_EtaLe27_ && NumConst>minNumCon_Tight_EtaLe27_;
+          pertightlepvetoJetID = NHF<maxNeutHadF_TightLepVeto_EtaLe27_ && NEMF<maxNeutEmF_TightLepVeto_EtaLe27_ && NumConst>minNumCon_TightLepVeto_EtaLe27_ && MUF<maxMuF_TightLepVeto_EtaLe27_;
           if( std::abs(eta) <= 2.4 )
           {
             perlooseJetID &= CHF>minChargHadF_Loose_EtaLe24_ && CHM>minChargMulti_Loose_EtaLe24_ && CEMF<maxChargEmF_Loose_EtaLe24_;
             pertightJetID &= CHF>minChargHadF_Tight_EtaLe24_ && CHM>minChargMulti_Tight_EtaLe24_ && CEMF<maxChargEmF_Tight_EtaLe24_;
+            pertightlepvetoJetID &= CHF>minChargHadF_TightLepVeto_EtaLe24_ && CHM>minChargMulti_TightLepVeto_EtaLe24_ && CEMF<maxChargEmF_TightLepVeto_EtaLe24_;
           }
         }
         else if( std::abs(eta) > 2.7 && std::abs(eta) <= 3.0 )
         {
           perlooseJetID = NEMF<maxNeutEmF_Loose_Eta27to30_ && NumNeutralParticle>minNumNeutPart_Loose_Eta27to30_;
           pertightJetID = NEMF<maxNeutEmF_Tight_Eta27to30_ && NumNeutralParticle>minNumNeutPart_Tight_Eta27to30_;
+          pertightlepvetoJetID = pertightJetID;
         }
         else
         {
           perlooseJetID = NEMF<maxNeutEmF_Loose_EtaGe30_ && NumNeutralParticle>minNumNeutPart_Loose_EtaGe30_;
           pertightJetID = NEMF<maxNeutEmF_Tight_EtaGe30_ && NumNeutralParticle>minNumNeutPart_Tight_EtaGe30_;
+          pertightlepvetoJetID = pertightJetID;
         }
 
         goodJetID &= perlooseJetID;
         goodJetIDtight &= pertightJetID;
+        goodJetIDtightlepveto &= pertightlepvetoJetID;
       }
     }
   }
 
   iEvent.put( std::auto_ptr<bool>(new bool(goodJetID)), "looseJetID" );
   iEvent.put( std::auto_ptr<bool>(new bool(goodJetIDtight)), "tightJetID" );
+  iEvent.put( std::auto_ptr<bool>(new bool(goodJetIDtightlepveto)), "tightlepvetoJetID" );
   //default is loose ID, but in general we use tagging mode
   return taggingMode_ || goodJetID;
 }

--- a/SkimsAUX/workdir/prod/80X_crab_example/treeMaker_stopRA2.py
+++ b/SkimsAUX/workdir/prod/80X_crab_example/treeMaker_stopRA2.py
@@ -208,7 +208,7 @@ elif options.cmsswVersion == "80X":
       jetCorrLevelLists = ['L1FastJet', 'L2Relative', 'L3Absolute', 'L2L3Residual']
 
 # Q/G discriminator
-qgDatabaseVersion = 'v1' # check https://twiki.cern.ch/twiki/bin/viewauth/CMS/QGDataBaseVersion
+qgDatabaseVersion = 'v2b' # check https://twiki.cern.ch/twiki/bin/viewauth/CMS/QGDataBaseVersion
 #import QG database
 from CondCore.DBCommon.CondDBSetup_cfi import *
 QGPoolDBESSource = cms.ESSource("PoolDBESSource",
@@ -771,10 +771,13 @@ process.stopTreeMaker.vectorString.append(cms.InputTag("triggerProducer", "Trigg
 #process.stopTreeMaker.varsInt.append(cms.InputTag("prodFilterOutScraping"))
 process.stopTreeMaker.varsBool.append(cms.InputTag("prodJetIDEventFilter", "looseJetID"))
 process.stopTreeMaker.varsBool.append(cms.InputTag("prodJetIDEventFilter", "tightJetID"))
+process.stopTreeMaker.varsBool.append(cms.InputTag("prodJetIDEventFilter", "tightlepvetoJetID"))
 process.stopTreeMaker.varsBool.append(cms.InputTag("prodJetIDEventFilterNoLep", "looseJetID"))
 process.stopTreeMaker.varsBoolNamesInTree.append("prodJetIDEventFilterNoLep:looseJetID|looseJetID_NoLep")
 process.stopTreeMaker.varsBool.append(cms.InputTag("prodJetIDEventFilterNoLep", "tightJetID"))
 process.stopTreeMaker.varsBoolNamesInTree.append("prodJetIDEventFilterNoLep:tightJetID|tightJetID_NoLep")
+process.stopTreeMaker.varsBool.append(cms.InputTag("prodJetIDEventFilterNoLep", "tightlepvetoJetID"))
+process.stopTreeMaker.varsBoolNamesInTree.append("prodJetIDEventFilterNoLep:tightlepvetoJetID|tightlepvetoJetID_NoLep")
 #process.stopTreeMaker.varsInt.append(cms.InputTag("METFilters"))
 #process.stopTreeMaker.varsInt.append(cms.InputTag("CSCTightHaloFilter")) # 74X txt files are ready for the 2015 working point, use this and not the flag in miniAOD 
 process.stopTreeMaker.varsInt.append(cms.InputTag("globalTightHalo2016Filter"))


### PR DESCRIPTION
As title described. 
I take a run on 1000 ttjets events, and find the average JetID for tight is 0.95 while the JetID tight lepton veto is 0.77....