### PR TITLE
Add HasVar() to NtupleReader

### DIFF
--- a/Tools/NTupleReader.cc
+++ b/Tools/NTupleReader.cc
@@ -236,3 +236,12 @@ std::vector<std::string> NTupleReader::GetTupleSpecs(std::string VarName) const
   
   return specs;
 }
+
+// ===  FUNCTION  ============================================================
+//         Name:  NTupleReader::HasVar
+//  Description:  
+// ===========================================================================
+bool NTupleReader::HasVar(std::string name) const
+{
+  return (typeMap_.find(name) != typeMap_.end());
+}       // -----  end of function NTupleReader::HasVar  -----

--- a/Tools/NTupleReader.cc
+++ b/Tools/NTupleReader.cc
@@ -241,7 +241,7 @@ std::vector<std::string> NTupleReader::GetTupleSpecs(std::string VarName) const
 //         Name:  NTupleReader::HasVar
 //  Description:  
 // ===========================================================================
-bool NTupleReader::HasVar(std::string name) const
+bool NTupleReader::hasVar(std::string name) const
 {
   return (typeMap_.find(name) != typeMap_.end());
 }       // -----  end of function NTupleReader::HasVar  -----

--- a/Tools/NTupleReader.h
+++ b/Tools/NTupleReader.h
@@ -90,6 +90,7 @@ public:
     bool getNextEvent();
     void disableUpdate();
     void printTupleMembers(FILE *f = stdout) const;
+    bool HasVar(std::string name) const;
     std::vector<std::string> GetTupleMembers() const;
     std::vector<std::string> GetTupleSpecs(std::string VarName = "cntNJetsPt30Eta24") const;
 

--- a/Tools/NTupleReader.h
+++ b/Tools/NTupleReader.h
@@ -90,7 +90,7 @@ public:
     bool getNextEvent();
     void disableUpdate();
     void printTupleMembers(FILE *f = stdout) const;
-    bool HasVar(std::string name) const;
+    bool hasVar(std::string name) const;
     std::vector<std::string> GetTupleMembers() const;
     std::vector<std::string> GetTupleSpecs(std::string VarName = "cntNJetsPt30Eta24") const;
 

--- a/Tools/baselineDef.cc
+++ b/Tools/baselineDef.cc
@@ -78,11 +78,11 @@ bool BaselineVessel::SetupTopTagger(bool UseNewTagger_, std::string CfgFile_)
 
   if (!UseNewTagger)
   {
-    type3Ptr = std::make_shared<topTagger::type3TopTagger>();
+    type3Ptr.reset(new topTagger::type3TopTagger);
   }
   if (UseNewTagger)
   {
-    ttPtr = std::make_shared<TopTagger>();
+    ttPtr.reset(new TopTagger);
     ttPtr->setCfgFile(toptaggerCfgFile);
   }
   


### PR DESCRIPTION
1. HasVar() allows user to check whether a variable is register in the ntuple.
This is needed to avoid handling all the throw and catch problems.
Even though we can catch the error. In a fast looping, it would cause so-called
double exceptions and crash the code (good to learn).
2. use Reset() with shared_ptr in handling the top tagger. This will remove the
current small memory leak.