### PR TITLE
change event to long int in stopTreeMaker

### DIFF
--- a/StopTreeMaker/interface/stopTreeMaker.h
+++ b/StopTreeMaker/interface/stopTreeMaker.h
@@ -48,7 +48,7 @@ private:
   // generell event information
   UInt_t runNum_;      
   UInt_t lumiBlockNum_;
-  UInt_t evtNum_;
+  ULong64_t evtNum_;
   
   // any float precision varialbes
   std::vector<edm::InputTag> varsDoubleTags_;

--- a/StopTreeMaker/src/stopTreeMaker.cc
+++ b/StopTreeMaker/src/stopTreeMaker.cc
@@ -137,7 +137,7 @@ VectorTLorentzVectorTags_.push_back(consumes<std::vector<TLorentzVector> >(tag))
 
   tree_->Branch("run",&runNum_,"run/i");
   tree_->Branch("lumi",&lumiBlockNum_,"lumi/i");
-  tree_->Branch("event",&evtNum_,"event/i");
+  tree_->Branch("event",&evtNum_,"event/l");
 
   if( debug_ ) std::cout<<std::endl;
   varsDouble_ = std::vector<double>(varsDoubleTags_.size(), 9999.);


### PR DESCRIPTION
change type of event in ntuple to long int to avoid negative value
Test by 
cmsRun treeMaker_stopRA2.py mcInfo=1 GlobalTag=80X_mcRun2_asymptotic_2016_TrancheIV_v6 specialFix=JEC jecDBname=Summer16_23Sep2016V3_MC maxEvents=100

aok