### PR TITLE
Jet Pt and Photon TLV Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ cmsenv
 
 ## TopTagger Repos
 
-Checkout and compile the TopTagger and TopTaggerTools repositories.
+Checkout and compile the TopTagger and TopTaggerTools repositories. The configure and make commands are also required after merging new TopTagger changes.
 
 ```
 cd $CMSSW_BASE/src
@@ -24,73 +24,23 @@ git clone git@github.com:susy2015/TopTagger.git
 git clone git@github.com:susy2015/TopTaggerTools.git
 cd TopTagger/TopTagger/test/
 ./configure
+make clean
 make -j 8 
 ```
-
-<details> <summary> OpenCV on cmslpc (no longer needed) </summary>
-
-Most users should no longer use OpenCV. Do this instead only if you need OpenCV. If you are not on the LPC and you need OpenCV, you will have to follow the instructions below to install OpenCV on your system.
-
-```
-cd TopTagger/TopTagger/test/
-./configure OPENCVDIR=/uscms_data/d3/pastika/zinv/dev/CMSSW_7_4_8/src/opencv/
-make -j 8 
-```
-
-</details>
-
-<details> <summary> Checkout OpenCV (no longer needed) </summary>
-
-```bash
-cd $CMSSW_BASE/src
-git clone git@github.com:susy2015/opencv.git
-cd opencv
-git checkout 3.1.0_StopBugFix
-cmake .
-make -j 8
-```
-
-</details>
-
 
 ## SusyAnaTools Repo
 
-Checkout and compile the SusyAnaTools repository.
+Checkout and compile the SusyAnaTools repository. The autoconf, configure, and make commands are also required after merging new SusyAnaTools changes.
 
 ```
 cd $CMSSW_BASE/src
 git clone git@github.com:susy2015/SusyAnaTools.git
 cd SusyAnaTools/Tools/
-git checkout NanoAOD
 autoconf
 ./configure
+make clean
 make -j 8 
 ```
-
-<details> <summary> OpenCV on cmslpc (no longer needed) </summary>
-
-Most users should no longer use OpenCV. Do this instead only if you need OpenCV. If you are not on the LPC and you need OpenCV, you will have to follow the instructions below to install OpenCV on your system.
-
-```
-cd SusyAnaTools/Tools/
-./configure OPENCVDIR=/uscms_data/d3/pastika/zinv/dev/CMSSW_7_4_8/src/opencv/
-make -j 8 
-```
-
-</details>
-
-<details> <summary> Checkout OpenCV (no longer needed) </summary>
-
-```bash
-cd $CMSSW_BASE/src
-git clone git@github.com:susy2015/opencv.git
-cd opencv
-git checkout 3.1.0_StopBugFix
-cmake .
-make -j 8
-```
-
-</details>
 
 ## Get Configuration Files
 
@@ -124,7 +74,7 @@ However, "-d" can be omitted and the files will be downloaded in your working di
 
 Checkout the stop search configuration files using the following tag.
 
-Current tag for NanoSUSY ntuples: PostProcessed_StopTuple_V2.9.1PostProcessed_StopTuple_V2.9.1
+Current tag for NanoSUSY ntuples: PostProcessed_StopNtuple_V2.9.3
 
 You may see all StopCfg releases/tags with release notes at https://github.com/susy2015/StopCfg/releases. 
 
@@ -132,12 +82,12 @@ Run this command from your working area, i.e. the directory where softlinks to t
 
 Command using full path:
 ```
-$CMSSW_BASE/src/SusyAnaTools/Tools/scripts/getStopCfg.sh -t PostProcessed_StopTuple_V2.9.1
+$CMSSW_BASE/src/SusyAnaTools/Tools/scripts/getStopCfg.sh -t PostProcessed_StopNtuple_V2.9.3
 ```
 
 Command if `SusyAnaTools/Tools/scripts` is in your PATH:
 ```
-getStopCfg.sh -t PostProcessed_StopTuple_V2.9.1
+getStopCfg.sh -t PostProcessed_StopNtuple_V2.9.3
 ```
 
 Please note that this script will download the desired configuration information in a seperate folder and softlink the necessary files into your corrent directory.

--- a/Tools/CleanedJets.h
+++ b/Tools/CleanedJets.h
@@ -51,10 +51,10 @@ private:
         const auto& Jet_TLV            = tr_->getVec<TLorentzVector>("JetTLV");
         const auto& FatJet_TLV         = tr_->getVec<TLorentzVector>("FatJetTLV");
         // use objects passing cuts for cleaning
-        const auto& Photon_TLV         = tr_->getVec<TLorentzVector>("gammaLVecPassLooseID");
+        const auto& Photon_TLV         = tr_->getVec<TLorentzVector>("cutPhotonTLV");
         const auto& Electron_TLV       = tr_->getVec<TLorentzVector>("cutElecVec");
         const auto& Muon_TLV           = tr_->getVec<TLorentzVector>("cutMuVec");
-        const auto& Photon_jetIdx      = tr_->getVec<int>("gammaJetIndexPassLooseID");
+        const auto& Photon_jetIdx      = tr_->getVec<int>("cutPhotonJetIndex");
         const auto& Electron_jetIdx    = tr_->getVec<int>("cutElecJetIndex");
         const auto& Muon_jetIdx        = tr_->getVec<int>("cutMuJetIndex");
         // jet matches object variables that we derive here

--- a/Tools/SusyUtility.cc
+++ b/Tools/SusyUtility.cc
@@ -3,6 +3,7 @@
 // December 13, 2018
 
 // utility functions
+#include "SusyAnaTools/Tools/SusyUtility.h"
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -20,6 +21,33 @@ namespace SusyUtility
             result.push_back(item);
         }
     }
+    
+    template<> 
+    bool greaterThan(const std::pair<TLorentzVector,unsigned int>& p1, const std::pair<TLorentzVector,unsigned int>& p2)
+    {
+        if (p1.first.Pt() == p2.first.Pt())
+        {
+            return abs(p1.first.Eta()) < abs(p2.first.Eta());
+        }
+        else
+        {
+            return p1.first.Pt() > p2.first.Pt();
+        }
+    }
+    
+    template<> 
+    bool lessThan(const std::pair<TLorentzVector,unsigned int>& p1, const std::pair<TLorentzVector,unsigned int>& p2)
+    {
+        if (p1.first.Pt() == p2.first.Pt())
+        {
+            return abs(p1.first.Eta()) > abs(p2.first.Eta());
+        }
+        else
+        {
+            return p1.first.Pt() < p2.first.Pt();
+        }
+    }
+    
     
     // return vector of strings given names separated by deliminator, e.g. "electron;muon" ---> {"electron", "muon"} 
     std::vector<std::string> getVecFromString(const std::string &s, const char& delim) {

--- a/Tools/SusyUtility.cc
+++ b/Tools/SusyUtility.cc
@@ -38,6 +38,7 @@ namespace SusyUtility
     // example: {"cut1", "cut2", "", "cut3"} ---> {"cut1", "cut1;cut2", "cut1;cut2", "cut1;cut2;cut3"}
     std::vector<std::string> getCutLevels(const std::vector<std::string> cuts)
     {
+        bool verbose = false;
         std::vector<std::string> cutLevels;
         std::string cutLevel;
         for (int i = 0; i < cuts.size(); ++i)
@@ -49,7 +50,10 @@ namespace SusyUtility
             cutLevel += cuts[i];
             cutLevels.push_back(cutLevel);
             // debugging
-            //printf("cut: %s cutLevel: %s\n", cuts[i].c_str(), cutLevel.c_str());
+            if (verbose)
+            {
+                printf("cut: %s cutLevel: %s\n", cuts[i].c_str(), cutLevel.c_str());
+            }
         }
         return cutLevels;
     }

--- a/Tools/SusyUtility.h
+++ b/Tools/SusyUtility.h
@@ -7,6 +7,7 @@
 #ifndef SUSYUTILITY_H 
 #define SUSYUTILITY_H 
 
+#include "TLorentzVector.h"
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -16,14 +17,24 @@
 namespace SusyUtility
 {
     void split(const std::string &s, const char& delim, std::vector<std::string>& result);
-    template<typename T1, typename T2> bool greaterThan(const std::pair<T1,T2>& p1, const std::pair<T1,T2>& p2)
+    
+    template<typename T1, typename T2> 
+    bool greaterThan(const std::pair<T1,T2>& p1, const std::pair<T1,T2>& p2)
     {
         return p1.first > p2.first;
     }
-    template<typename T1, typename T2> bool lessThan(const std::pair<T1,T2>& p1, const std::pair<T1,T2>& p2)
+
+    template<> 
+    bool greaterThan(const std::pair<TLorentzVector,unsigned int>& p1, const std::pair<TLorentzVector,unsigned int>& p2);
+
+    template<typename T1, typename T2> 
+    bool lessThan(const std::pair<T1,T2>& p1, const std::pair<T1,T2>& p2)
     {
         return p1.first < p2.first;
     }
+
+    template<> 
+    bool lessThan(const std::pair<TLorentzVector,unsigned int>& p1, const std::pair<TLorentzVector,unsigned int>& p2);
     
     // return vector of strings given names separated by deliminator, e.g. "electron;muon" ---> {"electron", "muon"} 
     std::vector<std::string> getVecFromString(const std::string &s, const char& delim);

--- a/Tools/baselineDef.cc
+++ b/Tools/baselineDef.cc
@@ -1874,17 +1874,17 @@ bool BaselineVessel::CalcBottomVars()
   int nBottoms = 0;
   int i = 0;
   
-  std::vector<std::pair<float, unsigned>> sorted_jets;
+  std::vector<std::pair<TLorentzVector, unsigned>> sorted_jets;
   std::vector<std::pair<float, unsigned>> disc_vec;
   i = 0;
   for (const auto& jet : jets)
   {
-    sorted_jets.push_back({jet.Pt(), i});
+    sorted_jets.push_back({jet, i});
     ++i;
   }
   
   // sort jets by pt (since JECs change jet pt)
-  std::sort(sorted_jets.begin(), sorted_jets.end(), SusyUtility::greaterThan<float, unsigned>);
+  std::sort(sorted_jets.begin(), sorted_jets.end(), SusyUtility::greaterThan<TLorentzVector, unsigned>);
   
   for (const auto& p : sorted_jets)
   {

--- a/Tools/baselineDef.cc
+++ b/Tools/baselineDef.cc
@@ -470,11 +470,11 @@ void BaselineVessel::PassBaseline()
   metLVec.SetPtEtaPhiM(tr->getVar<float>(METLabel), 0, tr->getVar<float>(METPhiLabel), 0);
   // Calculate deltaPhi
   std::vector<float> * dPhiVec = new std::vector<float>();
-  (*dPhiVec) = AnaFunctions::calcDPhi(Jets, metLVec, 5, AnaConsts::pt30Eta47Arr);
+  (*dPhiVec) = AnaFunctions::calcDPhi(Jets, metLVec, 5, AnaConsts::pt20Eta47Arr);
   // more vars
-  int nJets     = AnaFunctions::countJets(Jets,               AnaConsts::pt30Eta24Arr);  
-  int nFatJets  = AnaFunctions::countJets(FatJets,            AnaConsts::pt200Eta24Arr);  
-  float HT      = AnaFunctions::calcHT(Jets,    AnaConsts::pt30Eta24Arr);
+  int nJets     = AnaFunctions::countJets(Jets,     AnaConsts::pt20Eta24Arr);  
+  int nFatJets  = AnaFunctions::countJets(FatJets,  AnaConsts::pt200Eta24Arr);  
+  float HT      = AnaFunctions::calcHT(Jets,        AnaConsts::pt20Eta24Arr);
   float S_met   = met / sqrt(HT);
 
   //---------------------------------------//

--- a/Tools/baselineDef.cc
+++ b/Tools/baselineDef.cc
@@ -1621,7 +1621,7 @@ void BaselineVessel::PassHEMVeto()
     // https://github.com/susy2015/NanoSUSY-tools/blob/master/python/modules/Stop0lBaselineProducer.py#L236-L239
     const auto& Jets        = tr->getVec<TLorentzVector>(jetVecLabel);
     const auto& Electrons   = tr->getVec<TLorentzVector>("cutElecVec");
-    const auto& Photons     = tr->getVec<TLorentzVector>("gammaLVecPassLooseID");
+    const auto& Photons     = tr->getVec<TLorentzVector>("cutPhotonTLV");
     // use exact (narrow) window for electrons and photons: eta_low, eta_high, phi_low, phi_high = -3.0, -1.4, -1.57, -0.87
     // use extended (wide) window for jets:                 eta_low, eta_high, phi_low, phi_high = -3.2, -1.2, -1.77, -0.67
     float narrow_eta_low  = -3.0;

--- a/Tools/baselineDef.cc
+++ b/Tools/baselineDef.cc
@@ -789,18 +789,21 @@ void BaselineVessel::PassBaseline()
   //    printf("%d: event %d passes (Pass_EventFilter && Pass_JetID && SAT_Pass_lowDM_mid_dPh)i; baseline%s\n", tr->getEvtNum(), event, mySpec.c_str());
   //}
   
-  //unsigned long long CMS_event = tr->getVar<unsigned long long>("event");
+  unsigned long long CMS_event = tr->getVar<unsigned long long>("event");
   //printf("CMS event: %d ntuple event: %d\n", CMS_event, tr->getEvtNum());
   
   //if (tr->getEvtNum() == 7217)
-  //if (tr->getEvtNum() == 29144)
+  //if (CMS_event == 519215141)
   if (false)
   {
-    printf("event: %d; %d\n", event, tr->getEvtNum());
+    printf("CMS event: ntuple event: %d; %d\n", event, tr->getEvtNum());
+    printf("SAT_Pass_dPhiMETLowDM: %d\n", SAT_Pass_dPhiMETLowDM);
+    printf("SAT_Pass_dPhiMETHighDM: %d\n", SAT_Pass_dPhiMETHighDM);
     // dPhi
     printf("dPhi_0: %f ",           dPhiVec->at(0));
     printf("dPhi_1: %f ",           dPhiVec->at(1));
     printf("dPhi_2: %f ",           dPhiVec->at(2));
+    printf("dPhi_3: %f ",           dPhiVec->at(3));
     printf("met = %f ",             met);
     printf("metphi = %f ",          metphi);
     printf("HT = %f ",              HT);

--- a/Tools/baselineDef.cc
+++ b/Tools/baselineDef.cc
@@ -520,14 +520,15 @@ void BaselineVessel::PassBaseline()
   
   //SUS-16-049, low dm, ISR cut
   // see GetISRJetIdx() and CalcISRJetVars() for details
-  bool pass_ISR = (ISRJetPt >= 200);
+  bool SAT_Pass_ISR   = (ISRJetPt > 200);
+  bool SAT_Pass_S_MET = (S_met > 10);
   
   // ----------------------- // 
   // --- For Search Bins --- //
   // ----------------------- // 
   
   //SUS-16-049, low dm, mtb cut
-  bool pass_mtb_lowdm = (nBottoms == 0 || (nBottoms > 0 && mtb < 175));  
+  bool SAT_Pass_MTB_LowDM = (nBottoms == 0 || (nBottoms > 0 && mtb < 175));  
 
   //SUS-16-049, low dm, dphi(met, j1) > 0.5, dphi(met, j23) > 0.15
   bool SAT_Pass_dPhiMETLowDM = ( 
@@ -596,9 +597,9 @@ void BaselineVessel::PassBaseline()
                      && nMergedTops == 0
                      && nResolvedTops == 0
                      && nWs == 0
-                     && pass_ISR
-                     && S_met > 10
-                     && pass_mtb_lowdm
+                     && SAT_Pass_ISR
+                     && SAT_Pass_S_MET
+                     && SAT_Pass_MTB_LowDM
                    );      
   
   //baseline for SUS-16-049 high dm plus HT cut
@@ -624,9 +625,9 @@ void BaselineVessel::PassBaseline()
                         SAT_Pass_Baseline_Loose
                      && nMergedTops == 0
                      && nWs == 0
-                     && pass_ISR
-                     && S_met > 10
-                     && pass_mtb_lowdm
+                     && SAT_Pass_ISR
+                     && SAT_Pass_S_MET
+                     && SAT_Pass_MTB_LowDM
                   );      
   
   //baselinefor shapeFactor calculation (loose)
@@ -652,9 +653,9 @@ void BaselineVessel::PassBaseline()
                         SAT_Pass_Baseline_Mid
                      && nMergedTops == 0
                      && nWs == 0
-                     && pass_ISR
-                     && S_met > 10
-                     && pass_mtb_lowdm
+                     && SAT_Pass_ISR
+                     && SAT_Pass_S_MET
+                     && SAT_Pass_MTB_LowDM
                   );      
   
   //baselinefor shapeFactor calculation (mid)
@@ -696,9 +697,9 @@ void BaselineVessel::PassBaseline()
                      && nMergedTops == 0
                      && nResolvedTops == 0
                      && nWs == 0
-                     && pass_ISR
-                     && S_met > 10
-                     && pass_mtb_lowdm
+                     && SAT_Pass_ISR
+                     && SAT_Pass_S_MET
+                     && SAT_Pass_MTB_LowDM
                    );      
   
   //baseline for SUS-16-049 high dm plus HT cut
@@ -723,9 +724,9 @@ void BaselineVessel::PassBaseline()
                      && SAT_Pass_mid_dPhiMETLowDM 
                      && nMergedTops == 0
                      && nWs == 0
-                     && pass_ISR
-                     && S_met > 10
-                     && pass_mtb_lowdm
+                     && SAT_Pass_ISR
+                     && SAT_Pass_S_MET
+                     && SAT_Pass_MTB_LowDM
                    );      
   //baseline for SUS-16-049 high dm plus HT cut
   bool SAT_Pass_highDM_mid_dPhi_Loose = (
@@ -749,9 +750,9 @@ void BaselineVessel::PassBaseline()
                      && SAT_Pass_mid_dPhiMETLowDM 
                      && nMergedTops == 0
                      && nWs == 0
-                     && pass_ISR
-                     && S_met > 10
-                     && pass_mtb_lowdm
+                     && SAT_Pass_ISR
+                     && SAT_Pass_S_MET
+                     && SAT_Pass_MTB_LowDM
                    );      
   //baseline for SUS-16-049 high dm plus HT cut
   bool SAT_Pass_highDM_mid_dPhi_Mid = (
@@ -832,7 +833,7 @@ void BaselineVessel::PassBaseline()
     printf("ISRJetPt: %f ",         ISRJetPt);
     printf("Stop0l_ISRJetIdx: %d ", Stop0l_ISRJetIdx);
     printf("ISRJetIdx: %d ",        ISRJetIdx);
-    printf("pass_ISR: %d ",         pass_ISR);
+    printf("SAT_Pass_ISR: %d ",     SAT_Pass_ISR);
     // mtb and ptb variables
     printf("met = %f, metphi = %f\n",     met,        metphi);
     printf("Stop0l_Mtb = %f, mtb = %f\n", Stop0l_Mtb, mtb);
@@ -850,9 +851,13 @@ void BaselineVessel::PassBaseline()
   tr->registerDerivedVar("nMuons_Stop0l" + firstSpec, nMuons_Stop0l);
   tr->registerDerivedVar("nIsoTracks_Stop0l" + firstSpec, nIsoTracks_Stop0l);
   tr->registerDerivedVar("HT" + firstSpec, HT);
+  tr->registerDerivedVar("S_met" + firstSpec, S_met);
   tr->registerDerivedVar("SAT_Pass_MET" + firstSpec, SAT_Pass_MET);
   tr->registerDerivedVar("SAT_Pass_HT" + firstSpec, SAT_Pass_HT);
   tr->registerDerivedVar("SAT_Pass_NJets20" + firstSpec, SAT_Pass_NJets20);
+  tr->registerDerivedVar("SAT_Pass_ISR" + firstSpec, SAT_Pass_ISR);
+  tr->registerDerivedVar("SAT_Pass_S_MET" + firstSpec, SAT_Pass_S_MET);
+  tr->registerDerivedVar("SAT_Pass_MTB_LowDM" + firstSpec, SAT_Pass_MTB_LowDM);
   tr->registerDerivedVar("SAT_Pass_Baseline"  + firstSpec, SAT_Pass_Baseline);
   tr->registerDerivedVar("SAT_Pass_dPhiMETLowDM" + firstSpec,  SAT_Pass_dPhiMETLowDM);
   tr->registerDerivedVar("SAT_Pass_dPhiMETHighDM" + firstSpec, SAT_Pass_dPhiMETHighDM);

--- a/Tools/baselineDef.cc
+++ b/Tools/baselineDef.cc
@@ -788,7 +788,10 @@ void BaselineVessel::PassBaseline()
   //{
   //    printf("%d: event %d passes (Pass_EventFilter && Pass_JetID && SAT_Pass_lowDM_mid_dPh)i; baseline%s\n", tr->getEvtNum(), event, mySpec.c_str());
   //}
-
+  
+  //unsigned long long CMS_event = tr->getVar<unsigned long long>("event");
+  //printf("CMS event: %d ntuple event: %d\n", CMS_event, tr->getEvtNum());
+  
   //if (tr->getEvtNum() == 7217)
   //if (tr->getEvtNum() == 29144)
   if (false)

--- a/Tools/baselineDef.cc
+++ b/Tools/baselineDef.cc
@@ -782,20 +782,8 @@ void BaselineVessel::PassBaseline()
   // ------------------------------ //
   // --- print info for testing --- //
   // ------------------------------ //
-  
-  //std::string mySpec = "_normal";
-  //if (!firstSpec.empty())
-  //{
-  //  mySpec = firstSpec;
-  //}
-  //if (Pass_EventFilter && Pass_JetID && SAT_Pass_lowDM_mid_dPhi)
-  //{
-  //    printf("%d: event %d passes (Pass_EventFilter && Pass_JetID && SAT_Pass_lowDM_mid_dPh)i; baseline%s\n", tr->getEvtNum(), event, mySpec.c_str());
-  //}
-  
-  unsigned long long CMS_event = tr->getVar<unsigned long long>("event");
+  //unsigned long long CMS_event = tr->getVar<unsigned long long>("event");
   //printf("CMS event: %d ntuple event: %d\n", CMS_event, tr->getEvtNum());
-  
   //if (tr->getEvtNum() == 7217)
   //if (CMS_event == 519215141)
   if (false)
@@ -1879,7 +1867,7 @@ bool BaselineVessel::CalcBottomVars()
   const auto& event          = tr->getVar<unsigned long long>("event");
 
   bool verbose = false;
-  float pt_cut = 30.0;
+  float pt_cut = 20.0;
   float eta_cut = 2.4;
   float mtb = INFINITY;
   float ptb = 0.0;

--- a/Tools/condor/updateSamples.py
+++ b/Tools/condor/updateSamples.py
@@ -232,16 +232,14 @@ def main():
         except IOError:
             print TextColor.red + "ERROR opening nevents file {0}".format(nevents_file) + TextColor.end
             return
-    
-    # get nevents from file
-    if nevents_file_2:
-        # open nevents file if it is provided
-        try:
-            neventsFile2 = open(nevents_file_2, 'r')
-        except IOError:
-            print TextColor.red + "ERROR opening nevents file {0}".format(nevents_file_2) + TextColor.end
-            return
-    
+        # get nevents from file
+        if nevents_file_2:
+            # open nevents file if it is provided
+            try:
+                neventsFile2 = open(nevents_file_2, 'r')
+            except IOError:
+                print TextColor.red + "ERROR opening nevents file {0}".format(nevents_file_2) + TextColor.end
+                return
     # get xsections from file
     elif xsection_file:
         # open xsection file if it is provided
@@ -261,7 +259,6 @@ def main():
         except IOError:
             print TextColor.red + "ERROR opening xsection file {0}".format(xsection_file) + TextColor.end
             return
-
     # calculate nevents
     else:
         # only get weights using getNEvts() if nevents_file is not provided by user
@@ -280,6 +277,8 @@ def main():
 
     # for each sample, find the correct weights
     for sample in inputSamples:
+        # do this before stripping sample
+        newSample = sample
         # be careful: strip() removes spaces and endlines
         # we remove these for our conditions, but not for our new file
         sample = sample.strip()
@@ -294,7 +293,6 @@ def main():
         
         # update config file with n_events
         else:
-            newSample = sample
             # if line is empty (after being stripped), write original line (with endline) to file
             if not sample:
                 outputSamples.write(newSample)

--- a/Tools/customize.cc
+++ b/Tools/customize.cc
@@ -44,15 +44,15 @@ namespace AnaFunctions
     int cntNJets =0;
     int i = 0;
     
-    std::vector<std::pair<float, unsigned>> sorted_jets;
+    std::vector<std::pair<TLorentzVector, unsigned>> sorted_jets;
     for (const auto& jet : inputJets)
     {
-      sorted_jets.push_back({jet.Pt(), i});
+      sorted_jets.push_back({jet, i});
       ++i;
     }
     
     // sort jets by pt (since JEC change jet pt)
-    std::sort(sorted_jets.begin(), sorted_jets.end(), SusyUtility::greaterThan<float, unsigned>);
+    std::sort(sorted_jets.begin(), sorted_jets.end(), SusyUtility::greaterThan<TLorentzVector, unsigned>);
     
     std::vector<float> outDPhiVec(nDPhi, 999);
     //for(unsigned int i=0; i<inputJets.size(); i++){

--- a/Tools/customize.cc
+++ b/Tools/customize.cc
@@ -286,7 +286,7 @@ namespace AnaFunctions
 
   void preparecalcDPhi(const std::vector<TLorentzVector> &inijetsLVec, const TLorentzVector &metLVec, std::vector<float> &outDPhiVec){
     outDPhiVec.clear();
-    outDPhiVec = calcDPhi(inijetsLVec, metLVec, 5, AnaConsts::dphiArr);
+    outDPhiVec = calcDPhi(inijetsLVec, metLVec, 5, AnaConsts::pt20Eta47Arr);
   }
 
   void prepareForNtupleReader(){

--- a/Tools/customize.h
+++ b/Tools/customize.h
@@ -55,11 +55,12 @@ namespace AnaConsts{
    const float minJetPt = 30;
 //                               minAbsEta, maxAbsEta, minPt, maxPt
    const AccRec pt30Arr       = {   -1,        -1,      30,    -1  };
-   const AccRec pt30Eta24Arr  = {   -1,       2.4,      30,    -1  };
    const AccRec pt20Eta24Arr  = {   -1,       2.4,      20,    -1  };
+   const AccRec pt30Eta24Arr  = {   -1,       2.4,      30,    -1  };
    const AccRec pt50Eta24Arr  = {   -1,       2.4,      50,    -1  };
    const AccRec pt200Eta24Arr = {   -1,       2.4,     200,    -1  };
-   const AccRec dphiArr       = {   -1,       4.7,      20,    -1  };
+   const AccRec pt20Eta47Arr  = {   -1,       4.7,      20,    -1  };
+   const AccRec pt30Eta47Arr  = {   -1,       4.7,      20,    -1  };
    const AccRec dphiNArr      = {   -1,       2.4,      30,    -1  };
    const AccRec bTagArr       = {   -1,       2.4,      20,    -1  };
    const AccRec pt20Eta25Arr  = {   -1,       2.5,      20,    -1  };

--- a/Tools/samples.h
+++ b/Tools/samples.h
@@ -66,37 +66,13 @@ namespace AnaSamples
   bool operator== (const FileSummary& lhs, const FileSummary& rhs);
   bool operator!= (const FileSummary& lhs, const FileSummary& rhs);
 
-  // previously used luminosity (2016)
-  //static const double luminosity = 35866.210733056; // in pb-1
-
-  // --- Luminosities from Stealth Stop group (Kelvin and Nadja) --- //
-  // Single Electron Luminosity
-  //static const double luminosity_2016 = 35908.886; // in pb-1
-  //static const double luminosity_2017 = 41525.529; // in pb-1
-  // Single Muon Luminosity
-  //static const double luminosity_2016 = 35917.149; // in pb-1
-  //static const double luminosity_2017 = 41525.250; // in pb-1
-  // --------------------------------------------------------------- //
-
-  // Run 2 Dataset Luminosities
-  // Data_SingleElectron_2016:  35860.0 pb^(-1) 
-  // Data_SingleMuon_2016:      35922.0 pb^(-1)
-  // Data_SinglePhoton_2016:    35922.0 pb^(-1)
-  // Data_SingleElectron_2017:  TBD
-  // Data_SingleMuon_2017:      37620.0 pb^(-1)
-  // Data_SinglePhoton_2017:    41179.0 pb^(-1)
-  // Data_EGamma_2018:          57812.0 pb^(-1)
-  // Data_SingleMuon_2018:      58364.0 pb^(-1) 
- 
   //May 5, 2019: Updated Luminosities from PostProcessed_StopTuple_V2.7.2
-  //Question: Should Data_SingleElectron_2016 be 35860.0 (see PostProcess_StopTuple_V1.2.1)
   static const double luminosity_2016           = 35922.0; // in pb-1 (Data_SingleMuon_2016)
   static const double luminosity_2017           = 41856.0; // in pb-1 (Data_SingleElectron_2017)
   static const double luminosity_2018           = 58905.0; // in pb-1 (Data_EGamma_2018)
   static const double luminosity_2018_AB        = 20757.0; // in pb-1 (Data_EGamma_2018 Periods A + B)
   static const double luminosity_2018_CD        = 38148.0; // in pb-1 (Data_EGamma_2018 Periods C + D)
   // lumi per sample when datasets had different lumis
-  //static const double luminosity_electron_2016  = 18075.2; // in pb-1 for Data_SingleElectron_2016; compare to Stealth n_events, (35922.0 * 474181858.0 / 942371523.0) = 18075.207375590446
   static const double luminosity_electron_2016  = 35860.0; // in pb-1 for Data_SingleElectron_2016
   static const double luminosity_muon_2016      = 35922.0; // in pb-1 for Data_SingleMuon_2016
   static const double luminosity_photon_2016    = 35922.0; // in pb-1 for Data_SinglePhoton_2016 

--- a/Tools/searchBins.cc
+++ b/Tools/searchBins.cc
@@ -33,7 +33,6 @@ bool SearchBins::searchBinDef::compare(const int ibJet, const int iTop, const fl
 SearchBins::SearchBins(std::string binEra) :
   binEra_(binEra)
 {
-    std::cout<<"\nbinEra_ : "<<binEra_.c_str()<<std::endl<<std::endl;
     NSearchRegions_ = 0;
 
     if(binEra_.compare("SB_37_2015") == 0)


### PR DESCRIPTION
## Summary
- change jet pt  cut to 30 GeV for calculating nJets, HT, and dPhi
- rename photon variables; remove LooseID from name
- now updateSamples.py can compare n_events from two different n_events files

## Commits
* 0b8f116 Rename gamma\*PassLooseID to cutPhoton\*
* 0a9cf92 Remove commented code, change pt cut to 20 for b-jet variables.
* 4446e85 Use pt > 30 for jets to calculate all variables.
* a1ac881 check event for hui
* a3daff1 CMS event number debugging
* d0fb721 Define more booleans for use in cutflows.