### PR TITLE
Fix MiniTupleMaker array read bug

### DIFF
--- a/Tools/MiniTupleMaker.h
+++ b/Tools/MiniTupleMaker.h
@@ -39,15 +39,15 @@ private:
     template<typename T> void prepVar(const NTupleReader& tr, const std::string& name)
     {
         TBranch *tb = tree_->GetBranch(name.c_str());
-        if(!tb) tree_->Branch(name.c_str(), static_cast<T*>(const_cast<void*>(tr.getPtr(name))));
-        else       tb->SetAddress(const_cast<void*>(tr.getPtr(name)));
+        if(!tb) tree_->Branch(name.c_str(), static_cast<T*>(const_cast<void*>(tr.getPtr<T>(name))));
+        else       tb->SetAddress(const_cast<void*>(tr.getPtr<T>(name)));
     }
 
     template<typename T> void prepVec(const NTupleReader& tr, const std::string& name)
     {
         TBranch *tb = tree_->GetBranch(name.c_str());
-        if(!tb) tree_->Branch(name.c_str(), static_cast<std::vector<T>**>(const_cast<void*>(tr.getVecPtr(name))));
-        else       tb->SetAddress(const_cast<void*>(tr.getVecPtr(name)));
+        if(!tb) tree_->Branch(name.c_str(), static_cast<std::vector<T>**>(const_cast<void*>(tr.getVecPtr<T>(name))));
+        else       tb->SetAddress(const_cast<void*>(tr.getVecPtr<T>(name)));
     }
 };
 

--- a/Tools/NTupleReader.cc
+++ b/Tools/NTupleReader.cc
@@ -508,12 +508,12 @@ void* NTupleReader::getVarPtr(const std::string& var) const
     }
 }
 
-const void* NTupleReader::getPtr(const std::string& var) const
+template<> const void* NTupleReader::getPtr<void>(const std::string& var) const
 {
     return getVarPtr(var);
 }
 
-const void* NTupleReader::getVecPtr(const std::string& var) const
+template<> const void* NTupleReader::getVecPtr<void>(const std::string& var) const
 {
     //This function can be used to return the variable pointer
     try

--- a/Tools/NTupleReader.h
+++ b/Tools/NTupleReader.h
@@ -405,8 +405,33 @@ public:
 
     void addAlias(const std::string& name, const std::string& alias);
 
-    const void* getPtr(const std::string& var) const;
-    const void* getVecPtr(const std::string& var) const;
+    template<typename T = void> const void* getPtr(const std::string& var) const
+    {
+        try
+        {
+            return &getTupleObj<T>(var, branchMap_);
+        }
+        catch(const SATException& e)
+        {
+            if(isFirstEvent()) e.print();
+            if(reThrow_) throw;
+            return static_cast<T*>(nullptr);
+        }
+    }
+
+    template<typename T = void> const void* getVecPtr(const std::string& var) const
+    {
+        try
+        {
+            return &getTupleObj<std::vector<T>*>(var, branchVecMap_);
+        }
+        catch(const SATException& e)
+        {
+            if(isFirstEvent()) e.print();
+            if(reThrow_) throw;
+            return static_cast<std::vector<T>*>(nullptr);
+        }
+    }
 
     template<typename T> const T& getVar(const std::string& var) const
     {
@@ -698,5 +723,10 @@ private:
         return s;
     }
 };
+
+//template specializations
+template<> const void* NTupleReader::getPtr<void>(const std::string& var) const;
+template<> const void* NTupleReader::getVecPtr<void>(const std::string& var) const;
+
 
 #endif


### PR DESCRIPTION
Fix a bug where MiniTupleMaker would not read the size of an array correctly on the first event