### PR TITLE
Don't Run PassTrigger()

### DIFF
--- a/Tools/baselineDef.cc
+++ b/Tools/baselineDef.cc
@@ -1523,7 +1523,7 @@ void BaselineVessel::operator()(NTupleReader& tr_)
   UseCleanedJets();
   CalcBottomVars();
   CalcISRJetVars();
-  PassTrigger();
+  //PassTrigger(); // now done in post-processing as of v2.7
   PassJetID();
   PassEventFilter();
   PassHEMVeto();


### PR DESCRIPTION
- don't run PassTrigger() anymore
- pass trigger variables now done in post-processing as of v2.7