### PR TITLE
Fix Fat Jet Selections

### DIFF
--- a/Tools/CleanedJets.h
+++ b/Tools/CleanedJets.h
@@ -195,6 +195,7 @@ public:
         AK4JetVariables_ = {
                              // custom
                              "JetTLV",              
+                             "Jet_Stop0l",
                              "Jet_btagStop0l",
                              // from Nano AOD 
                              "Jet_area",
@@ -237,6 +238,7 @@ public:
                              // custom
                              "FatJetTLV",              
                              "SubJetTLV_AK8Matched",              
+                             "FatJet_Stop0l",
                              // from Nano AOD 
                              "FatJet_area",
                              // not a vector... cannot clean

--- a/Tools/RunTopTagger.h
+++ b/Tools/RunTopTagger.h
@@ -147,8 +147,8 @@ private:
         std::vector<std::vector<TLorentzVector>> subjets(nFatJets);
         for(int i = 0; i < nFatJets; ++i)
         {
-            if(FatJet_subJetIdx1[i] >= 0 && FatJet_subJetIdx1[i] < nSubJets) subjets[i].push_back(SubJet_LV[i]);
-            if(FatJet_subJetIdx2[i] >= 0 && FatJet_subJetIdx2[i] < nSubJets) subjets[i].push_back(SubJet_LV[i]);
+            if(FatJet_subJetIdx1[i] >= 0 && FatJet_subJetIdx1[i] < nSubJets) subjets[i].push_back(SubJet_LV[FatJet_subJetIdx1[i]]);
+            if(FatJet_subJetIdx2[i] >= 0 && FatJet_subJetIdx2[i] < nSubJets) subjets[i].push_back(SubJet_LV[FatJet_subJetIdx2[i]]);
         }
 
         //Create top tagger input helpers
@@ -261,6 +261,7 @@ private:
         tr.registerDerivedVec("ResolvedTops_disc" + suffix_,        ResolvedTops_disc);
         tr.registerDerivedVec("ResolvedTops_JetsMap" + suffix_,     ResolvedTops_JetsMap);
         tr.registerDerivedVar("nAllTops" + suffix_,                 nAllTops);
+        tr.registerDerivedVar("ttr" + suffix_,                      &ttr);
         //tr.registerDerivedVec("TopJetsMap" + suffix_,           TopJetsMap);
     }
     

--- a/Tools/RunTopTagger.h
+++ b/Tools/RunTopTagger.h
@@ -81,15 +81,18 @@ private:
 
 
 
-        auto* AllTopsTLV        = new std::vector<TLorentzVector>();
-        auto* MergedTopsTLV     = new std::vector<TLorentzVector>();
-        auto* SemiMergedTopsTLV = new std::vector<TLorentzVector>();
-        auto* ResolvedTopsTLV   = new std::vector<TLorentzVector>();
-        auto* WTLV              = new std::vector<TLorentzVector>();
-        auto* TopJetsMap        = new std::map< int , std::vector<TLorentzVector> >();
+        auto* MergedTopsTLV         = new std::vector<TLorentzVector>();
+        auto* MergedTops_disc       = new std::vector<double>();
+        auto* MergedTops_JetsMap    = new std::map< int , std::vector<TLorentzVector> >();
+        auto* WTLV                  = new std::vector<TLorentzVector>();
+        auto* W_disc                = new std::vector<double>();
+        auto* W_JetsMap             = new std::map< int , std::vector<TLorentzVector> >();
+        auto* ResolvedTopsTLV       = new std::vector<TLorentzVector>();
+        auto* ResolvedTops_disc     = new std::vector<double>();
+        auto* ResolvedTops_JetsMap  = new std::map< int , std::vector<TLorentzVector> >();
+        //auto* TopJetsMap            = new std::map< int , std::vector<TLorentzVector> >();
         int nAllTops        = 0;
         int nMergedTops     = 0;
-        int nSemiMergedTops = 0;
         int nResolvedTops   = 0;
         int nWs             = 0;
 
@@ -158,97 +161,80 @@ private:
         //make top tagger constituents, order matters here, ak4Inputs must not come after resInputs as the ak4Inputs are needed to build the resolved top candidates 
         std::vector<Constituent> constituents = packageConstituents(ak4Inputs, resInputs, ak8Inputs);
         
-        // TopTagger
-        //std::cout << "Create TopTagger object" << std::endl;
-        //TopTagger tt("TopTagger.cfg", ".");
-
         //run top tager
-        //std::cout << "tt_->runTagger(constituents)" << std::endl;
-        //tt.runTagger(constituents);
         tt_->runTagger(constituents);
 
 
         //get tagger results 
-        //std::cout << "Get TopTagger results" << std::endl;
         const TopTaggerResults& ttr = tt_->getResults();
 
         //print top properties
         //get reconstructed tops
         const std::vector<TopObject*>& tops = ttr.getTops();
         
-        // --- version using topsByType map
-        // --- requires different loops and reordering of AllTops
-        //
-        // std::map<TopObject::Type, std::vector<TopObject*>> topsByType = ttr.getTopsByType();
-        // const std::vector<TopObject*>& MergedTops     = topsByType[TopObject::Type::MERGED_TOP];
-        // const std::vector<TopObject*>& SemiMergedTops = topsByType[TopObject::Type::SEMIMERGEDWB_TOP];
-        // const std::vector<TopObject*>& ResolvedTops   = topsByType[TopObject::Type::RESOLVED_TOP];
-        // const std::vector<TopObject*>& Ws             = topsByType[TopObject::Type::MERGED_W];
-        // nMergedTops = MergedTops.size();
-        // nSemiMergedTops = SemiMergedTops.size();
-        // nResolvedTops = ResolvedTops.size();
-        // nAllTops = nMergedTops + nSemiMergedTops + nResolvedTops;
-        // nWs = Ws.size();
-        // for (const auto* top : MergedTops)      MergedTopsTLV->push_back(top->p());
-        // for (const auto* top : SemiMergedTops)  SemiMergedTopsTLV->push_back(top->p());
-        // for (const auto* top : ResolvedTops)    ResolvedTopsTLV->push_back(top->p());
-        // for (const auto* top : Ws)              WTLV->push_back(top->p());
-        //
-        // --- version using topsByType map
 
         bool printTops = false;
 
         if (printTops) std::cout << "----------------------------------------------------------------------" << std::endl;
-        unsigned int topidx = 0;
+        //unsigned int topidx = 0;
+        unsigned int MergedTopIdx   = 0;
+        unsigned int WIdx           = 0;
+        unsigned int ResolvedTopIdx = 0;
         for(const TopObject* top : tops)
         {
+            //print basic top properties (top->p() gives a TLorentzVector)
+            //N constituents refers to the number of jets included in the top
+            //3 for resolved tops 
+            //2 for W+jet tops
+            //1 for fully merged AK8 tops
+            if (printTops) printf("\tTop properties: Type: %3d,   Pt: %6.1lf,   Eta: %7.3lf,   Phi: %7.3lf,   M: %7.3lf\n", static_cast<int>(top->getType()), top->p().Pt(), top->p().Eta(), top->p().Phi(), top->p().M());
+
+            //get vector of top constituents 
+            const std::vector<Constituent const *>& constituents = top->getConstituents();
+            std::vector<TLorentzVector> temp;
+
+            //Print properties of individual top constituent jets 
+            for(const Constituent* constituent : constituents)
+            {
+                if (printTops) printf("\t\tConstituent properties: Constituent type: %3d,   Pt: %6.1lf,   Eta: %7.3lf,   Phi: %7.3lf\n", constituent->getType(), constituent->p().Pt(), constituent->p().Eta(), constituent->p().Phi());
+                temp.push_back(constituent->p());
+            }                
+            
+            //TopJetsMap->insert(std::make_pair(topidx, temp));
+            
             TopObject::Type type = top->getType();
             //if (tops.size() > 1) std::cout << "  top type: " << type << std::endl;
-            //std::cout << "  top type: " << type << std::endl;
             
-            if (type == TopObject::Type::MERGED_W)          WTLV->push_back(top->p());
-
-            //std::cout << "  top type: " << type << std::endl;
-            if (   type == TopObject::Type::MERGED_TOP
-                || type == TopObject::Type::SEMIMERGEDWB_TOP
-                || type == TopObject::Type::RESOLVED_TOP)
+            if (type == TopObject::Type::MERGED_TOP)        
             {
-                AllTopsTLV->push_back(top->p());
-                if (type == TopObject::Type::MERGED_TOP)        MergedTopsTLV->push_back(top->p());
-                if (type == TopObject::Type::SEMIMERGEDWB_TOP)  SemiMergedTopsTLV->push_back(top->p());
-                if (type == TopObject::Type::RESOLVED_TOP)      ResolvedTopsTLV->push_back(top->p());
-
-                //print basic top properties (top->p() gives a TLorentzVector)
-                //N constituents refers to the number of jets included in the top
-                //3 for resolved tops 
-                //2 for W+jet tops
-                //1 for fully merged AK8 tops
-                
-                if (printTops) printf("\tTop properties: Type: %3d,   Pt: %6.1lf,   Eta: %7.3lf,   Phi: %7.3lf,   M: %7.3lf\n", static_cast<int>(top->getType()), top->p().Pt(), top->p().Eta(), top->p().Phi(), top->p().M());
-
-                //get vector of top constituents 
-                const std::vector<Constituent const *>& constituents = top->getConstituents();
-                std::vector<TLorentzVector> temp;
-
-                //Print properties of individual top constituent jets 
-                for(const Constituent* constituent : constituents)
-                {
-                    if (printTops) printf("\t\tConstituent properties: Constituent type: %3d,   Pt: %6.1lf,   Eta: %7.3lf,   Phi: %7.3lf\n", constituent->getType(), constituent->p().Pt(), constituent->p().Eta(), constituent->p().Phi());
-                    temp.push_back(constituent->p());
-                }                
-                TopJetsMap->insert(std::make_pair(topidx, temp));
-                ++topidx;
+                MergedTopsTLV->push_back(top->p());
+                MergedTops_disc->push_back(top->getDiscriminator());
+                MergedTops_JetsMap->insert(std::make_pair(MergedTopIdx, temp));
+                ++MergedTopIdx;
             }
+            if (type == TopObject::Type::MERGED_W)          
+            {
+                WTLV->push_back(top->p());
+                W_disc->push_back(top->getDiscriminator());
+                W_JetsMap->insert(std::make_pair(WIdx, temp));
+                ++WIdx;
+            }
+            if (type == TopObject::Type::RESOLVED_TOP)      
+            {
+                ResolvedTopsTLV->push_back(top->p());
+                ResolvedTops_disc->push_back(top->getDiscriminator());
+                ResolvedTops_JetsMap->insert(std::make_pair(ResolvedTopIdx, temp));
+                ++ResolvedTopIdx;
+            }
+
+            //++topidx;
         }
 
         // number of tops
         //use post-processed selections to calcualte number of merged tops and Ws 
-        nAllTops        = AllTopsTLV->size();
         //nMergedTops     = MergedTopsTLV->size();
-        nSemiMergedTops = SemiMergedTopsTLV->size();
-        nResolvedTops   = ResolvedTopsTLV->size();
         //nWs             = WTLV->size();
-        
+        nResolvedTops   = ResolvedTopsTLV->size();
         
         //print the number of tops found in the event 
         //if (tops.size() > 1)
@@ -257,23 +243,25 @@ private:
             printf("tops.size() =  %ld ",      tops.size());
             printf("nAllTops =  %ld ",         nAllTops);
             printf("nMergedTops =  %ld ",      nMergedTops);
-            printf("nSemiMergedTops =  %ld ",  nSemiMergedTops);
-            printf("nResolvedTops =  %ld ",    nResolvedTops);
             printf("nWs =  %ld ",              nWs);
+            printf("nResolvedTops =  %ld ",    nResolvedTops);
             std::cout << std::endl;
         }
         
-        tr.registerDerivedVec("AllTopsTLV" + suffix_,           AllTopsTLV);
-        tr.registerDerivedVec("MergedTopsTLV" + suffix_,        MergedTopsTLV);
-        tr.registerDerivedVec("SemiMergedTopsTLV" + suffix_,    SemiMergedTopsTLV);
-        tr.registerDerivedVec("ResolvedTopsTLV" + suffix_,      ResolvedTopsTLV);
-        tr.registerDerivedVec("WTLV" + suffix_,                 WTLV);
-        tr.registerDerivedVec("TopJetsMap" + suffix_,           TopJetsMap);
-        tr.registerDerivedVar("nAllTops" + suffix_,             nAllTops);
-        tr.registerDerivedVar("nMergedTops" + suffix_,          nMergedTops);
-        tr.registerDerivedVar("nSemiMergedTops" + suffix_,      nSemiMergedTops);
-        tr.registerDerivedVar("nResolvedTops" + suffix_,        nResolvedTops);
-        tr.registerDerivedVar("nWs" + suffix_,                  nWs);
+        tr.registerDerivedVar("nMergedTops" + suffix_,              nMergedTops);
+        tr.registerDerivedVec("MergedTopsTLV" + suffix_,            MergedTopsTLV);
+        tr.registerDerivedVec("MergedTops_disc" + suffix_,          MergedTops_disc);
+        tr.registerDerivedVec("MergedTops_JetsMap" + suffix_,       MergedTops_JetsMap);
+        tr.registerDerivedVar("nWs" + suffix_,                      nWs);
+        tr.registerDerivedVec("WTLV" + suffix_,                     WTLV);
+        tr.registerDerivedVec("W_disc" + suffix_,                   W_disc);
+        tr.registerDerivedVec("W_JetsMap" + suffix_,                W_JetsMap);
+        tr.registerDerivedVar("nResolvedTops" + suffix_,            nResolvedTops);
+        tr.registerDerivedVec("ResolvedTopsTLV" + suffix_,          ResolvedTopsTLV);
+        tr.registerDerivedVec("ResolvedTops_disc" + suffix_,        ResolvedTops_disc);
+        tr.registerDerivedVec("ResolvedTops_JetsMap" + suffix_,     ResolvedTops_JetsMap);
+        tr.registerDerivedVar("nAllTops" + suffix_,                 nAllTops);
+        //tr.registerDerivedVec("TopJetsMap" + suffix_,           TopJetsMap);
     }
     
 public:

--- a/Tools/RunTopTagger.h
+++ b/Tools/RunTopTagger.h
@@ -55,6 +55,7 @@ private:
         const auto& FatJet_msoftdrop       = tr.getVec<float>("FatJet_msoftdrop");
         const auto& FatJet_subJetIdx1      = tr.getVec<int>("FatJet_subJetIdx1");
         const auto& FatJet_subJetIdx2      = tr.getVec<int>("FatJet_subJetIdx2");
+        const auto& FatJet_Stop0l          = tr.getVec<int>("FatJet_Stop0l");
         std::vector<bool> FatJet_matchesPhoton;
         std::vector<bool> FatJet_matchesElectron;
         std::vector<bool> FatJet_matchesMuon;
@@ -119,6 +120,8 @@ private:
         {
             //no need to slow the tagger down considering low pt jets
             if(FatJet_LV[i].Pt() < 200.0) ak8Filter[i] = false;
+            // apply Stop0l fat jet selection
+            //if(! FatJet_Stop0l[i])        ak8Filter[i] = false;
 
             //do some logic here to decide which jet was lepton/photon matched
             if (doLeptonCleaning_)

--- a/Tools/RunTopTagger.h
+++ b/Tools/RunTopTagger.h
@@ -87,11 +87,11 @@ private:
         auto* ResolvedTopsTLV   = new std::vector<TLorentzVector>();
         auto* WTLV              = new std::vector<TLorentzVector>();
         auto* TopJetsMap        = new std::map< int , std::vector<TLorentzVector> >();
-        int nAllTops        = -1;
-        int nMergedTops     = -1;
-        int nSemiMergedTops = -1;
-        int nResolvedTops   = -1;
-        int nWs             = -1;
+        int nAllTops        = 0;
+        int nMergedTops     = 0;
+        int nSemiMergedTops = 0;
+        int nResolvedTops   = 0;
+        int nWs             = 0;
 
         //Select AK4 jets to use in tagger
         //When reading from the resolvedTopCandidate collection from nanoAOD you must pass ALL ak4 jets to ttUtility::ConstAK4Inputs below, 
@@ -120,8 +120,6 @@ private:
         {
             //no need to slow the tagger down considering low pt jets
             if(FatJet_LV[i].Pt() < 200.0) ak8Filter[i] = false;
-            // apply Stop0l fat jet selection
-            //if(! FatJet_Stop0l[i])        ak8Filter[i] = false;
 
             //do some logic here to decide which jet was lepton/photon matched
             if (doLeptonCleaning_)
@@ -131,6 +129,12 @@ private:
             if (doPhotonCleaning_)
             {
                 if (FatJet_matchesPhoton[i]) ak8Filter[i] = false;
+            }
+            //use post-processed selections to calcualte number of merged tops and Ws 
+            if(ak8Filter[i])
+            {
+                if(FatJet_Stop0l[i] == 1) nMergedTops += 1;
+                if(FatJet_Stop0l[i] == 2) nWs         += 1;
             }
         }
 
@@ -238,11 +242,13 @@ private:
         }
 
         // number of tops
+        //use post-processed selections to calcualte number of merged tops and Ws 
         nAllTops        = AllTopsTLV->size();
-        nMergedTops     = MergedTopsTLV->size();
+        //nMergedTops     = MergedTopsTLV->size();
         nSemiMergedTops = SemiMergedTopsTLV->size();
         nResolvedTops   = ResolvedTopsTLV->size();
-        nWs             = WTLV->size();
+        //nWs             = WTLV->size();
+        
         
         //print the number of tops found in the event 
         //if (tops.size() > 1)

--- a/Tools/baselineDef.cc
+++ b/Tools/baselineDef.cc
@@ -526,6 +526,7 @@ void BaselineVessel::PassBaseline()
   const auto& ResolvedTopsTLV       = tr->getVec<TLorentzVector>(UseCleanedJetsVar("ResolvedTopsTLV"));
   const auto& ResolvedTops_disc     = tr->getVec<double>(UseCleanedJetsVar("ResolvedTops_disc"));
   const auto& ResolvedTops_JetsMap  = tr->getMap<int, std::vector<TLorentzVector>>(UseCleanedJetsVar("ResolvedTops_JetsMap"));
+  const auto* ttr                   = tr->getVar<TopTaggerResults*>("ttr");
   // variables from post-processing
   const auto& nSoftBottoms          = tr->getVar<int>("Stop0l_nSoftb");;
   const auto& Stop0l_ISRJetPt       = tr->getVar<float>("Stop0l_ISRJetPt");
@@ -859,39 +860,52 @@ void BaselineVessel::PassBaseline()
     printf("\thui_Stop0l_nTop       = %d and caleb_nMergedTops            = %d\n", Stop0l_nTop, nMergedTops);
     printf("\thui_Stop0l_nW         = %d and caleb_nWs                    = %d\n", Stop0l_nW, nWs);
     printf("\thui_Stop0l_nResolved  = %d and caleb_nResolvedTops          = %d\n", Stop0l_nResolved, nResolvedTops);
-    for (int i = 0; i < MergedTopsTLV.size(); ++i)
+    for(const auto& top : ttr->getTops())
     {
-        const auto& jets_ = MergedTops_JetsMap.at(i);
-        printf("\tMergedTop %d: (pt=%f, eta=%f, phi=%f, mass=%f), disc=%f\n", i, MergedTopsTLV[i].Pt(), MergedTopsTLV[i].Eta(), MergedTopsTLV[i].Phi(), MergedTopsTLV[i].M(), MergedTops_disc[i]);
-        int j = 0;
-        for (const auto& jet : jets_)
+        printf("\tpt=%f, eta=%f, phi=%f, mass=%f, disc=%f, type=%d\n", top->p().Pt(), top->p().Eta(), top->p().Phi(), top->p().M(), top->getDiscriminator(), top->getType());
+        for (const auto& jet : top->getConstituents())
         {
-            printf("\t\tjet %d: (pt=%f, eta=%f, phi=%f, mass=%f)\n", i, jet.Pt(), jet.Eta(), jet.Phi(), jet.M());
-            ++j;
+            printf("\t\tjet: (pt=%f, eta=%f, phi=%f, mass=%f)\n", jet->p().Pt(), jet->p().Eta(), jet->p().Phi(), jet->p().M());
+            for(const auto& subjet : jet->getSubjets())
+            {
+                printf("\t\t\tsubjet: (pt=%f, eta=%f, phi=%f, mass=%f)\n", subjet.p().Pt(), subjet.p().Eta(), subjet.p().Phi(), subjet.p().M());
+            }
         }
+        
     }
-    for (int i = 0; i < WTLV.size(); ++i)
-    {
-        const auto& jets_ = W_JetsMap.at(i);
-        printf("\tW %d: (pt=%f, eta=%f, phi=%f, mass=%f), disc=%f\n", i, WTLV[i].Pt(), WTLV[i].Eta(), WTLV[i].Phi(), WTLV[i].M(), W_disc[i]);
-        int j = 0;
-        for (const auto& jet : jets_)
-        {
-            printf("\t\tjet %d: (pt=%f, eta=%f, phi=%f, mass=%f)\n", i, jet.Pt(), jet.Eta(), jet.Phi(), jet.M());
-            ++j;
-        }
-    }
-    for (int i = 0; i < ResolvedTopsTLV.size(); ++i)
-    {
-        const auto& jets_ = ResolvedTops_JetsMap.at(i);
-        printf("\tResolvedTop %d: (pt=%f, eta=%f, phi=%f, mass=%f), disc=%f\n", i, ResolvedTopsTLV[i].Pt(), ResolvedTopsTLV[i].Eta(), ResolvedTopsTLV[i].Phi(), ResolvedTopsTLV[i].M(), ResolvedTops_disc[i]);
-        int j = 0;
-        for (const auto& jet : jets_)
-        {
-            printf("\t\tjet %d: (pt=%f, eta=%f, phi=%f, mass=%f)\n", i, jet.Pt(), jet.Eta(), jet.Phi(), jet.M());
-            ++j;
-        }
-    }
+//    for (int i = 0; i < MergedTopsTLV.size(); ++i)
+//    {
+//        const auto& jets_ = MergedTops_JetsMap.at(i);
+//        printf("\tMergedTop %d: (pt=%f, eta=%f, phi=%f, mass=%f), disc=%f\n", i, MergedTopsTLV[i].Pt(), MergedTopsTLV[i].Eta(), MergedTopsTLV[i].Phi(), MergedTopsTLV[i].M(), MergedTops_disc[i]);
+//        int j = 0;
+//        for (const auto& jet : jets_)
+//        {
+//            printf("\t\tjet %d: (pt=%f, eta=%f, phi=%f, mass=%f)\n", i, jet.Pt(), jet.Eta(), jet.Phi(), jet.M());
+//            ++j;
+//        }
+//    }
+//    for (int i = 0; i < WTLV.size(); ++i)
+//    {
+//        const auto& jets_ = W_JetsMap.at(i);
+//        printf("\tW %d: (pt=%f, eta=%f, phi=%f, mass=%f), disc=%f\n", i, WTLV[i].Pt(), WTLV[i].Eta(), WTLV[i].Phi(), WTLV[i].M(), W_disc[i]);
+//        int j = 0;
+//        for (const auto& jet : jets_)
+//        {
+//            printf("\t\tjet %d: (pt=%f, eta=%f, phi=%f, mass=%f)\n", i, jet.Pt(), jet.Eta(), jet.Phi(), jet.M());
+//            ++j;
+//        }
+//    }
+//    for (int i = 0; i < ResolvedTopsTLV.size(); ++i)
+//    {
+//        const auto& jets_ = ResolvedTops_JetsMap.at(i);
+//        printf("\tResolvedTop %d: (pt=%f, eta=%f, phi=%f, mass=%f), disc=%f\n", i, ResolvedTopsTLV[i].Pt(), ResolvedTopsTLV[i].Eta(), ResolvedTopsTLV[i].Phi(), ResolvedTopsTLV[i].M(), ResolvedTops_disc[i]);
+//        int j = 0;
+//        for (const auto& jet : jets_)
+//        {
+//            printf("\t\tjet %d: (pt=%f, eta=%f, phi=%f, mass=%f)\n", i, jet.Pt(), jet.Eta(), jet.Phi(), jet.M());
+//            ++j;
+//        }
+//    }
     if (verbose)
     {
       printf("SAT_Pass_dPhiMETLowDM: %d\n", SAT_Pass_dPhiMETLowDM);

--- a/Tools/baselineDef.cc
+++ b/Tools/baselineDef.cc
@@ -508,34 +508,43 @@ void BaselineVessel::PassBaseline()
   // https://github.com/susy2015/SusyAnaTools/blob/5e4f54e1aa985daff90f1ad7a220b8d17e4b7290/Tools/tupleRead.C#L629-L639
   
   // variables for SAT_Pass_lowDM and SAT_Pass_highDM
-  const auto& event             = tr->getVar<unsigned long long>("event");
-  const auto& nMergedTops       = tr->getVar<int>(UseCleanedJetsVar("nMergedTops"));
-  const auto& nResolvedTops     = tr->getVar<int>(UseCleanedJetsVar("nResolvedTops"));
-  const auto& nWs               = tr->getVar<int>(UseCleanedJetsVar("nWs"));
-  const auto& nBottoms          = tr->getVar<int>(UseCleanedJetsVar("nBottoms"));
-  const auto& mtb               = tr->getVar<float>(UseCleanedJetsVar("mtb"));
-  const auto& ptb               = tr->getVar<float>(UseCleanedJetsVar("ptb"));
-  const auto& ISRJetPt          = tr->getVar<float>(UseCleanedJetsVar("ISRJetPt"));
-  const auto& ISRJetIdx         = tr->getVar<int>(UseCleanedJetsVar("ISRJetIdx"));
+  const auto& event                 = tr->getVar<unsigned long long>("event");
+  const auto& nMergedTops           = tr->getVar<int>(UseCleanedJetsVar("nMergedTops"));
+  const auto& nWs                   = tr->getVar<int>(UseCleanedJetsVar("nWs"));
+  const auto& nResolvedTops         = tr->getVar<int>(UseCleanedJetsVar("nResolvedTops"));
+  const auto& nBottoms              = tr->getVar<int>(UseCleanedJetsVar("nBottoms"));
+  const auto& mtb                   = tr->getVar<float>(UseCleanedJetsVar("mtb"));
+  const auto& ptb                   = tr->getVar<float>(UseCleanedJetsVar("ptb"));
+  const auto& ISRJetPt              = tr->getVar<float>(UseCleanedJetsVar("ISRJetPt"));
+  const auto& ISRJetIdx             = tr->getVar<int>(UseCleanedJetsVar("ISRJetIdx"));
+  const auto& MergedTopsTLV         = tr->getVec<TLorentzVector>(UseCleanedJetsVar("MergedTopsTLV"));
+  const auto& MergedTops_disc       = tr->getVec<double>(UseCleanedJetsVar("MergedTops_disc"));
+  const auto& MergedTops_JetsMap    = tr->getMap<int, std::vector<TLorentzVector>>(UseCleanedJetsVar("MergedTops_JetsMap"));
+  const auto& WTLV                  = tr->getVec<TLorentzVector>(UseCleanedJetsVar("WTLV"));
+  const auto& W_disc                = tr->getVec<double>(UseCleanedJetsVar("W_disc"));
+  const auto& W_JetsMap             = tr->getMap<int, std::vector<TLorentzVector>>(UseCleanedJetsVar("W_JetsMap"));
+  const auto& ResolvedTopsTLV       = tr->getVec<TLorentzVector>(UseCleanedJetsVar("ResolvedTopsTLV"));
+  const auto& ResolvedTops_disc     = tr->getVec<double>(UseCleanedJetsVar("ResolvedTops_disc"));
+  const auto& ResolvedTops_JetsMap  = tr->getMap<int, std::vector<TLorentzVector>>(UseCleanedJetsVar("ResolvedTops_JetsMap"));
   // variables from post-processing
-  const auto& nSoftBottoms      = tr->getVar<int>("Stop0l_nSoftb");;
-  const auto& Stop0l_ISRJetPt   = tr->getVar<float>("Stop0l_ISRJetPt");
-  const auto& Stop0l_ISRJetIdx  = tr->getVar<int>("Stop0l_ISRJetIdx");
-  const auto& Stop0l_Mtb        = tr->getVar<float>("Stop0l_Mtb");
-  const auto& Stop0l_Ptb        = tr->getVar<float>("Stop0l_Ptb");
-  const auto& Stop0l_nTop       = tr->getVar<int>("Stop0l_nTop");
-  const auto& Stop0l_nResolved  = tr->getVar<int>("Stop0l_nResolved");
-  const auto& Stop0l_nW         = tr->getVar<int>("Stop0l_nW");
-  const auto& Stop0l_METSig     = tr->getVar<float>("Stop0l_METSig");
-  const auto& Pass_lowDM        = tr->getVar<bool>("Pass_lowDM");
-  const auto& Pass_highDM       = tr->getVar<bool>("Pass_highDM");
-  bool Pass_JetID               = tr->getVar<bool>("Pass_JetID");
-  bool Pass_EventFilter         = tr->getVar<bool>("Pass_EventFilter");
-  bool Pass_MET                 = tr->getVar<bool>("Pass_MET");
-  bool Pass_HT                  = tr->getVar<bool>("Pass_HT");
-  bool Pass_NJets               = tr->getVar<bool>("Pass_NJets20");
-  bool Pass_dPhiMETLowDM        = tr->getVar<bool>("Pass_dPhiMETLowDM");
-  bool Pass_LeptonVeto          = tr->getVar<bool>("Pass_LeptonVeto");
+  const auto& nSoftBottoms          = tr->getVar<int>("Stop0l_nSoftb");;
+  const auto& Stop0l_ISRJetPt       = tr->getVar<float>("Stop0l_ISRJetPt");
+  const auto& Stop0l_ISRJetIdx      = tr->getVar<int>("Stop0l_ISRJetIdx");
+  const auto& Stop0l_Mtb            = tr->getVar<float>("Stop0l_Mtb");
+  const auto& Stop0l_Ptb            = tr->getVar<float>("Stop0l_Ptb");
+  const auto& Stop0l_nTop           = tr->getVar<int>("Stop0l_nTop");
+  const auto& Stop0l_nResolved      = tr->getVar<int>("Stop0l_nResolved");
+  const auto& Stop0l_nW             = tr->getVar<int>("Stop0l_nW");
+  const auto& Stop0l_METSig         = tr->getVar<float>("Stop0l_METSig");
+  const auto& Pass_lowDM            = tr->getVar<bool>("Pass_lowDM");
+  const auto& Pass_highDM           = tr->getVar<bool>("Pass_highDM");
+  bool Pass_JetID                   = tr->getVar<bool>("Pass_JetID");
+  bool Pass_EventFilter             = tr->getVar<bool>("Pass_EventFilter");
+  bool Pass_MET                     = tr->getVar<bool>("Pass_MET");
+  bool Pass_HT                      = tr->getVar<bool>("Pass_HT");
+  bool Pass_NJets                   = tr->getVar<bool>("Pass_NJets20");
+  bool Pass_dPhiMETLowDM            = tr->getVar<bool>("Pass_dPhiMETLowDM");
+  bool Pass_LeptonVeto              = tr->getVar<bool>("Pass_LeptonVeto");
   
   bool SAT_Pass_MET_Loose   = (met >= 100);
   bool SAT_Pass_MET_Mid     = (met >= 160);
@@ -832,7 +841,8 @@ void BaselineVessel::PassBaseline()
   //if (event == 519215141)
   //if (SAT_Pass_lowDM != Pass_lowDM && firstSpec.empty())
   //if (event == 1401471244)
-  if (verbose)
+  bool topDifference = bool(Stop0l_nTop != nMergedTops || Stop0l_nResolved != nResolvedTops || Stop0l_nW != nWs);
+  if (topDifference && firstSpec.empty())
   {
     printf("firstSpec: %s; CMS event: %d ntuple event: %d\n", firstSpec.c_str(), event, tr->getEvtNum());
     printf("Pass_lowDM = %d and SAT_Pass_lowDM = %d\n", Pass_lowDM, SAT_Pass_lowDM);
@@ -843,12 +853,45 @@ void BaselineVessel::PassBaseline()
     printf("\thui_Pass_HT           = %d and caleb_SAT_Pass_HT            = %d\n", Pass_HT, SAT_Pass_HT);
     printf("\thui_Pass_NJets        = %d and caleb_SAT_Pass_NJets         = %d\n", Pass_NJets, SAT_Pass_NJets);
     printf("\thui_Pass_dPhiMETLowDM = %d and caleb_SAT_Pass_dPhiMETLowDM  = %d\n", Pass_dPhiMETLowDM, SAT_Pass_dPhiMETLowDM);
-    printf("\thui_Stop0l_nTop       = %d and caleb_nMergedTops            = %d\n", Stop0l_nTop, nMergedTops);
-    printf("\thui_Stop0l_nResolved  = %d and caleb_nResolvedTops          = %d\n", Stop0l_nResolved, nResolvedTops);
-    printf("\thui_Stop0l_nW         = %d and caleb_nWs                    = %d\n", Stop0l_nW, nWs);
     printf("\thui_Stop0l_ISRJetPt   = %f and caleb_ISRJetPt               = %f\n", Stop0l_ISRJetPt, ISRJetPt);
     printf("\thui_Stop0l_METSig     = %f and caleb_S_met                  = %f\n", Stop0l_METSig, S_met);
     printf("\thui_Stop0l_Mtb        = %f and caleb_mtb                    = %f\n", Stop0l_Mtb, mtb);
+    printf("\thui_Stop0l_nTop       = %d and caleb_nMergedTops            = %d\n", Stop0l_nTop, nMergedTops);
+    printf("\thui_Stop0l_nW         = %d and caleb_nWs                    = %d\n", Stop0l_nW, nWs);
+    printf("\thui_Stop0l_nResolved  = %d and caleb_nResolvedTops          = %d\n", Stop0l_nResolved, nResolvedTops);
+    for (int i = 0; i < MergedTopsTLV.size(); ++i)
+    {
+        const auto& jets_ = MergedTops_JetsMap.at(i);
+        printf("\tMergedTop %d: (pt=%f, eta=%f, phi=%f, mass=%f), disc=%f\n", i, MergedTopsTLV[i].Pt(), MergedTopsTLV[i].Eta(), MergedTopsTLV[i].Phi(), MergedTopsTLV[i].M(), MergedTops_disc[i]);
+        int j = 0;
+        for (const auto& jet : jets_)
+        {
+            printf("\t\tjet %d: (pt=%f, eta=%f, phi=%f, mass=%f)\n", i, jet.Pt(), jet.Eta(), jet.Phi(), jet.M());
+            ++j;
+        }
+    }
+    for (int i = 0; i < WTLV.size(); ++i)
+    {
+        const auto& jets_ = W_JetsMap.at(i);
+        printf("\tW %d: (pt=%f, eta=%f, phi=%f, mass=%f), disc=%f\n", i, WTLV[i].Pt(), WTLV[i].Eta(), WTLV[i].Phi(), WTLV[i].M(), W_disc[i]);
+        int j = 0;
+        for (const auto& jet : jets_)
+        {
+            printf("\t\tjet %d: (pt=%f, eta=%f, phi=%f, mass=%f)\n", i, jet.Pt(), jet.Eta(), jet.Phi(), jet.M());
+            ++j;
+        }
+    }
+    for (int i = 0; i < ResolvedTopsTLV.size(); ++i)
+    {
+        const auto& jets_ = ResolvedTops_JetsMap.at(i);
+        printf("\tResolvedTop %d: (pt=%f, eta=%f, phi=%f, mass=%f), disc=%f\n", i, ResolvedTopsTLV[i].Pt(), ResolvedTopsTLV[i].Eta(), ResolvedTopsTLV[i].Phi(), ResolvedTopsTLV[i].M(), ResolvedTops_disc[i]);
+        int j = 0;
+        for (const auto& jet : jets_)
+        {
+            printf("\t\tjet %d: (pt=%f, eta=%f, phi=%f, mass=%f)\n", i, jet.Pt(), jet.Eta(), jet.Phi(), jet.M());
+            ++j;
+        }
+    }
     if (verbose)
     {
       printf("SAT_Pass_dPhiMETLowDM: %d\n", SAT_Pass_dPhiMETLowDM);

--- a/Tools/baselineDef.cc
+++ b/Tools/baselineDef.cc
@@ -524,6 +524,7 @@ void BaselineVessel::PassBaseline()
   const auto& Stop0l_nTop       = tr->getVar<int>("Stop0l_nTop");
   const auto& Stop0l_nResolved  = tr->getVar<int>("Stop0l_nResolved");
   const auto& Stop0l_nW         = tr->getVar<int>("Stop0l_nW");
+  const auto& Stop0l_METSig     = tr->getVar<float>("Stop0l_METSig");
   const auto& Pass_lowDM        = tr->getVar<bool>("Pass_lowDM");
   const auto& Pass_highDM       = tr->getVar<bool>("Pass_highDM");
   bool Pass_JetID               = tr->getVar<bool>("Pass_JetID");
@@ -829,14 +830,20 @@ void BaselineVessel::PassBaseline()
   //if (CMS_event == 519215141)
   if (SAT_Pass_lowDM != Pass_lowDM)
   {
-    printf("CMS event: ntuple event: %d; %d\n", event, tr->getEvtNum());
+    printf("firstSpec: %s; CMS event: %d ntuple event: %d\n", firstSpec.c_str(), event, tr->getEvtNum());
     printf("Pass_lowDM = %d and SAT_Pass_lowDM = %d\n", Pass_lowDM, SAT_Pass_lowDM);
-    printf("\tPass_JetID = %d and SAT_Pass_JetID = %d\n", Pass_JetID, SAT_Pass_JetID);
-    printf("\tPass_EventFilter = %d and SAT_Pass_EventFilter = %d\n", Pass_EventFilter, SAT_Pass_EventFilter);
-    printf("\tPass_MET = %d and SAT_Pass_MET = %d\n", Pass_MET, SAT_Pass_MET);
-    printf("\tPass_HT = %d and SAT_Pass_HT = %d\n", Pass_HT, SAT_Pass_HT);
-    printf("\tPass_NJets = %d and SAT_Pass_NJets = %d\n", Pass_NJets, SAT_Pass_NJets);
-    printf("\tPass_dPhiMETLowDM = %d and SAT_Pass_dPhiMETLowDM = %d\n", Pass_dPhiMETLowDM, SAT_Pass_dPhiMETLowDM);
+    printf("\thui_Pass_JetID        = %d and caleb_SAT_Pass_JetID         = %d\n", Pass_JetID, SAT_Pass_JetID);
+    printf("\thui_Pass_EventFilter  = %d and caleb_SAT_Pass_EventFilter   = %d\n", Pass_EventFilter, SAT_Pass_EventFilter);
+    printf("\thui_Pass_MET          = %d and caleb_SAT_Pass_MET           = %d\n", Pass_MET, SAT_Pass_MET);
+    printf("\thui_Pass_HT           = %d and caleb_SAT_Pass_HT            = %d\n", Pass_HT, SAT_Pass_HT);
+    printf("\thui_Pass_NJets        = %d and caleb_SAT_Pass_NJets         = %d\n", Pass_NJets, SAT_Pass_NJets);
+    printf("\thui_Pass_dPhiMETLowDM = %d and caleb_SAT_Pass_dPhiMETLowDM  = %d\n", Pass_dPhiMETLowDM, SAT_Pass_dPhiMETLowDM);
+    printf("\thui_Stop0l_nTop       = %d and caleb_nMergedTops            = %d\n", Stop0l_nTop, nMergedTops);
+    printf("\thui_Stop0l_nResolved  = %d and caleb_nResolvedTops          = %d\n", Stop0l_nResolved, nResolvedTops);
+    printf("\thui_Stop0l_nW         = %d and caleb_nWs                    = %d\n", Stop0l_nW, nWs);
+    printf("\thui_Stop0l_ISRJetPt   = %f and caleb_ISRJetPt               = %f\n", Stop0l_ISRJetPt, ISRJetPt);
+    printf("\thui_Stop0l_METSig     = %f and caleb_S_met                  = %f\n", Stop0l_METSig, S_met);
+    printf("\thui_Stop0l_Mtb        = %f and caleb_mtb                    = %f\n", Stop0l_Mtb, mtb);
     if (verbose)
     {
       printf("SAT_Pass_dPhiMETLowDM: %d\n", SAT_Pass_dPhiMETLowDM);

--- a/Tools/baselineDef.cc
+++ b/Tools/baselineDef.cc
@@ -845,6 +845,7 @@ void BaselineVessel::PassBaseline()
   bool topDifference = bool(Stop0l_nTop != nMergedTops || Stop0l_nResolved != nResolvedTops || Stop0l_nW != nWs);
   if (topDifference && firstSpec.empty())
   {
+    printf("WARNING: Difference in number of tops and/or Ws found!\n");
     printf("firstSpec: %s; CMS event: %d ntuple event: %d\n", firstSpec.c_str(), event, tr->getEvtNum());
     printf("Pass_lowDM = %d and SAT_Pass_lowDM = %d\n", Pass_lowDM, SAT_Pass_lowDM);
     printf("\thui_Pass_LeptonVeto   = %d and caleb_SAT_Pass_LeptonVeto    = %d\n", Pass_LeptonVeto, SAT_Pass_LeptonVeto);
@@ -1686,14 +1687,14 @@ void BaselineVessel::PassEventFilter()
     const auto& Flag_EcalDeadCellTriggerPrimitiveFilter     = tr->getVar<bool>("Flag_EcalDeadCellTriggerPrimitiveFilter");
     const auto& Flag_BadPFMuonFilter                        = tr->getVar<bool>("Flag_BadPFMuonFilter");
     const auto& Flag_BadChargedCandidateFilter              = tr->getVar<bool>("Flag_BadChargedCandidateFilter");
-    const auto& Flag_ecalBadCalibFilter                     = tr->getVar<bool>("Flag_ecalBadCalibFilter");
     const auto& Flag_globalSuperTightHalo2016Filter         = tr->getVar<bool>("Flag_globalSuperTightHalo2016Filter");
-    const auto& Flag_eeBadScFilter                          = tr->getVar<bool>("Flag_eeBadScFilter");
+    const auto& Pass_CaloMETRatio                           = tr->getVar<bool>("Pass_CaloMETRatio");
     // Note: Don't apply Flag_globalSuperTightHalo2016Filter to fastsim samples if you use fastsim
     // Note: Apply Flag_eeBadScFilter to Data but not MC
     // Note: Don't apply Flag_ecalBadCalibFilter to 2016, but apply it to 2017 and 2018
+    // Note: Add Pass_CaloMETRatio to event filter and see if it works
     SAT_Pass_EventFilter =   Flag_goodVertices && Flag_HBHENoiseFilter && Flag_HBHENoiseIsoFilter && Flag_EcalDeadCellTriggerPrimitiveFilter
-                          && Flag_BadPFMuonFilter && Flag_BadChargedCandidateFilter && Flag_globalSuperTightHalo2016Filter;
+                          && Flag_BadPFMuonFilter && Flag_BadChargedCandidateFilter && Flag_globalSuperTightHalo2016Filter && Pass_CaloMETRatio;
     tr->registerDerivedVar("SAT_Pass_EventFilter"+firstSpec, SAT_Pass_EventFilter);
 }
 

--- a/Tools/baselineDef.cc
+++ b/Tools/baselineDef.cc
@@ -828,11 +828,11 @@ void BaselineVessel::PassBaseline()
   // ------------------------------ //
   // --- print info for testing --- //
   // ------------------------------ //
-  //unsigned long long CMS_event = tr->getVar<unsigned long long>("event");
-  //printf("CMS event: %d ntuple event: %d\n", CMS_event, tr->getEvtNum());
   //if (tr->getEvtNum() == 7217)
-  //if (CMS_event == 519215141)
-  if (SAT_Pass_lowDM != Pass_lowDM && firstSpec.empty())
+  //if (event == 519215141)
+  //if (SAT_Pass_lowDM != Pass_lowDM && firstSpec.empty())
+  //if (event == 1401471244)
+  if (verbose)
   {
     printf("firstSpec: %s; CMS event: %d ntuple event: %d\n", firstSpec.c_str(), event, tr->getEvtNum());
     printf("Pass_lowDM = %d and SAT_Pass_lowDM = %d\n", Pass_lowDM, SAT_Pass_lowDM);

--- a/Tools/baselineDef.cc
+++ b/Tools/baselineDef.cc
@@ -506,7 +506,6 @@ void BaselineVessel::PassBaseline()
   // https://github.com/susy2015/SusyAnaTools/blob/5e4f54e1aa985daff90f1ad7a220b8d17e4b7290/Tools/tupleRead.C#L629-L639
   
   // variables for SAT_Pass_lowDM and SAT_Pass_highDM
-  
   const auto& event             = tr->getVar<unsigned long long>("event");
   const auto& nMergedTops       = tr->getVar<int>(UseCleanedJetsVar("nMergedTops"));
   const auto& nResolvedTops     = tr->getVar<int>(UseCleanedJetsVar("nResolvedTops"));
@@ -516,6 +515,7 @@ void BaselineVessel::PassBaseline()
   const auto& ptb               = tr->getVar<float>(UseCleanedJetsVar("ptb"));
   const auto& ISRJetPt          = tr->getVar<float>(UseCleanedJetsVar("ISRJetPt"));
   const auto& ISRJetIdx         = tr->getVar<int>(UseCleanedJetsVar("ISRJetIdx"));
+  // variables from post-processing
   const auto& nSoftBottoms      = tr->getVar<int>("Stop0l_nSoftb");;
   const auto& Stop0l_ISRJetPt   = tr->getVar<float>("Stop0l_ISRJetPt");
   const auto& Stop0l_ISRJetIdx  = tr->getVar<int>("Stop0l_ISRJetIdx");
@@ -524,6 +524,15 @@ void BaselineVessel::PassBaseline()
   const auto& Stop0l_nTop       = tr->getVar<int>("Stop0l_nTop");
   const auto& Stop0l_nResolved  = tr->getVar<int>("Stop0l_nResolved");
   const auto& Stop0l_nW         = tr->getVar<int>("Stop0l_nW");
+  const auto& Pass_lowDM        = tr->getVar<bool>("Pass_lowDM");
+  const auto& Pass_highDM       = tr->getVar<bool>("Pass_highDM");
+  bool Pass_JetID               = tr->getVar<bool>("Pass_JetID");
+  bool Pass_EventFilter         = tr->getVar<bool>("Pass_EventFilter");
+  bool Pass_MET                 = tr->getVar<bool>("Pass_MET");
+  bool Pass_HT                  = tr->getVar<bool>("Pass_HT");
+  bool Pass_NJets               = tr->getVar<bool>("Pass_NJets20");
+  bool Pass_dPhiMETLowDM        = tr->getVar<bool>("Pass_dPhiMETLowDM");
+  bool Pass_LeptonVeto          = tr->getVar<bool>("Pass_LeptonVeto");
   
   bool SAT_Pass_MET_Loose   = (met >= 100);
   bool SAT_Pass_MET_Mid     = (met >= 160);
@@ -534,9 +543,8 @@ void BaselineVessel::PassBaseline()
   bool SAT_Pass_LeptonVeto  = (Pass_ElecVeto && Pass_MuonVeto && Pass_TauVeto && Pass_IsoTrkVeto);
   bool SAT_Pass_JetID       = tr->getVar<bool>("SAT_Pass_JetID"+firstSpec);
   bool SAT_Pass_EventFilter = tr->getVar<bool>("SAT_Pass_EventFilter"+firstSpec);
-  bool Pass_JetID           = tr->getVar<bool>("Pass_JetID");
-  bool Pass_EventFilter     = tr->getVar<bool>("Pass_EventFilter");
-  bool Pass_LeptonVeto      = tr->getVar<bool>("Pass_LeptonVeto");
+
+  // check that lepton vetos match
   if (Pass_LeptonVeto != SAT_Pass_LeptonVeto) std::cout << "ERROR: Lepton vetos do not agree. Pass_LeptonVeto=" << Pass_LeptonVeto << " and SAT_Pass_LeptonVeto=" << SAT_Pass_LeptonVeto << std::endl;
  
   // get ISR jet
@@ -819,33 +827,43 @@ void BaselineVessel::PassBaseline()
   //printf("CMS event: %d ntuple event: %d\n", CMS_event, tr->getEvtNum());
   //if (tr->getEvtNum() == 7217)
   //if (CMS_event == 519215141)
-  if (false)
+  if (SAT_Pass_lowDM != Pass_lowDM)
   {
     printf("CMS event: ntuple event: %d; %d\n", event, tr->getEvtNum());
-    printf("SAT_Pass_dPhiMETLowDM: %d\n", SAT_Pass_dPhiMETLowDM);
-    printf("SAT_Pass_dPhiMETHighDM: %d\n", SAT_Pass_dPhiMETHighDM);
-    // dPhi
-    printf("dPhi_0: %f ",           dPhiVec->at(0));
-    printf("dPhi_1: %f ",           dPhiVec->at(1));
-    printf("dPhi_2: %f ",           dPhiVec->at(2));
-    printf("dPhi_3: %f ",           dPhiVec->at(3));
-    printf("met = %f ",             met);
-    printf("metphi = %f ",          metphi);
-    printf("HT = %f ",              HT);
-    printf("mtb = %f ",             mtb);
-    printf("ptb = %f ",             ptb);
-    printf("ISRJetPt = %f ",        ISRJetPt);
-    printf("S_met = %f ",           S_met);
-    printf("nJets = %d ",           nJets);
-    printf("nMergedTops = %d ",     nMergedTops);
-    printf("nBottoms = %d ",        nBottoms);
-    printf("nWs = %d ",             nWs);
-    printf("\n");
-    int i = 0;
-    for (const auto& Jet : Jets)
+    printf("Pass_lowDM = %d and SAT_Pass_lowDM = %d\n", Pass_lowDM, SAT_Pass_lowDM);
+    printf("\tPass_JetID = %d and SAT_Pass_JetID = %d\n", Pass_JetID, SAT_Pass_JetID);
+    printf("\tPass_EventFilter = %d and SAT_Pass_EventFilter = %d\n", Pass_EventFilter, SAT_Pass_EventFilter);
+    printf("\tPass_MET = %d and SAT_Pass_MET = %d\n", Pass_MET, SAT_Pass_MET);
+    printf("\tPass_HT = %d and SAT_Pass_HT = %d\n", Pass_HT, SAT_Pass_HT);
+    printf("\tPass_NJets = %d and SAT_Pass_NJets = %d\n", Pass_NJets, SAT_Pass_NJets);
+    printf("\tPass_dPhiMETLowDM = %d and SAT_Pass_dPhiMETLowDM = %d\n", Pass_dPhiMETLowDM, SAT_Pass_dPhiMETLowDM);
+    if (verbose)
     {
-      printf("Jet %d: pt=%f, eta=%f, phi=%f, mass=%f\n", i, Jet.Pt(), Jet.Eta(), Jet.Phi(), Jet.M());
-      ++i;
+      printf("SAT_Pass_dPhiMETLowDM: %d\n", SAT_Pass_dPhiMETLowDM);
+      printf("SAT_Pass_dPhiMETHighDM: %d\n", SAT_Pass_dPhiMETHighDM);
+      // dPhi
+      printf("dPhi_0: %f ",           dPhiVec->at(0));
+      printf("dPhi_1: %f ",           dPhiVec->at(1));
+      printf("dPhi_2: %f ",           dPhiVec->at(2));
+      printf("dPhi_3: %f ",           dPhiVec->at(3));
+      printf("met = %f ",             met);
+      printf("metphi = %f ",          metphi);
+      printf("HT = %f ",              HT);
+      printf("mtb = %f ",             mtb);
+      printf("ptb = %f ",             ptb);
+      printf("ISRJetPt = %f ",        ISRJetPt);
+      printf("S_met = %f ",           S_met);
+      printf("nJets = %d ",           nJets);
+      printf("nMergedTops = %d ",     nMergedTops);
+      printf("nBottoms = %d ",        nBottoms);
+      printf("nWs = %d ",             nWs);
+      printf("\n");
+      int i = 0;
+      for (const auto& Jet : Jets)
+      {
+        printf("Jet %d: pt=%f, eta=%f, phi=%f, mass=%f\n", i, Jet.Pt(), Jet.Eta(), Jet.Phi(), Jet.M());
+        ++i;
+      }
     }
   }
 


### PR DESCRIPTION
- Use loose DeepCSV working point for the ISR jet selection
- Use FatJet_Stop0l[i] to select merged tops and Ws
- Fix use of sub jet indices for fat jets when running the top tagger

```
FatJet_Stop0l[i] = 1 for merged tops, 2 for Ws
```