### PR TITLE
Use gen weight

### DIFF
--- a/Tools/CleanedJets.h
+++ b/Tools/CleanedJets.h
@@ -28,6 +28,8 @@ private:
     std::vector<std::string> AK4JetVariables_;
     // AK8 jet variables
     std::vector<std::string> AK8JetVariables_;
+    // soft bottom quark variables
+    std::vector<std::string> SoftBottomVariables_;
     
     NTupleReader* tr_;
     void setReader(NTupleReader& tr) { tr_ = &tr; }
@@ -38,10 +40,12 @@ private:
         registerJetMatchesObject();
 
         //                  jetCollectionName, jetCollectionVariables, prefix, suffix, doLeptonCleaning, doPhotonCleaning, doJetCuts
-        cleanJetCollection("Jet",      AK4JetVariables_, "", "_drLeptonCleaned", true,  false, false);
-        cleanJetCollection("Jet",      AK4JetVariables_, "", "_drPhotonCleaned", false, true,  false);
-        cleanJetCollection("FatJet",   AK8JetVariables_, "", "_drLeptonCleaned", true,  false, false);
-        cleanJetCollection("FatJet",   AK8JetVariables_, "", "_drPhotonCleaned", false, true,  false);
+        cleanJetCollection("Jet",      AK4JetVariables_,     "", "_drLeptonCleaned", true,  false, false);
+        cleanJetCollection("Jet",      AK4JetVariables_,     "", "_drPhotonCleaned", false, true,  false);
+        cleanJetCollection("FatJet",   AK8JetVariables_,     "", "_drLeptonCleaned", true,  false, false);
+        cleanJetCollection("FatJet",   AK8JetVariables_,     "", "_drPhotonCleaned", false, true,  false);
+        cleanJetCollection("SB",       SoftBottomVariables_, "", "_drLeptonCleaned", true,  false, false);
+        cleanJetCollection("SB",       SoftBottomVariables_, "", "_drPhotonCleaned", false, true,  false);
     
     }
 
@@ -50,6 +54,7 @@ private:
         //TODO: use photon and leptons passing cuts and ID for jet cleaning (instead of all photons and leptons)
         const auto& Jet_TLV            = tr_->getVec<TLorentzVector>("JetTLV");
         const auto& FatJet_TLV         = tr_->getVec<TLorentzVector>("FatJetTLV");
+        const auto& SB_TLV             = tr_->getVec<TLorentzVector>("SBTLV");
         // use objects passing cuts for cleaning
         const auto& Photon_TLV         = tr_->getVec<TLorentzVector>("cutPhotonTLV");
         const auto& Electron_TLV       = tr_->getVec<TLorentzVector>("cutElecVec");
@@ -64,15 +69,21 @@ private:
         auto& FatJet_matchesPhoton     = tr_->createDerivedVec<bool>("FatJet_matchesPhoton");
         auto& FatJet_matchesElectron   = tr_->createDerivedVec<bool>("FatJet_matchesElectron");
         auto& FatJet_matchesMuon       = tr_->createDerivedVec<bool>("FatJet_matchesMuon");
+        auto& SB_matchesPhoton         = tr_->createDerivedVec<bool>("SB_matchesPhoton");
+        auto& SB_matchesElectron       = tr_->createDerivedVec<bool>("SB_matchesElectron");
+        auto& SB_matchesMuon           = tr_->createDerivedVec<bool>("SB_matchesMuon");
         
         const float DRMAX_AK4 = 0.2;
         const float DRMAX_AK8 = 0.4;
-        Jet_matchesPhoton      = AnaFunctions::getJetMatchesObjectVec(Jet_TLV,    Photon_TLV,   Photon_jetIdx,      DRMAX_AK4);
-        Jet_matchesElectron    = AnaFunctions::getJetMatchesObjectVec(Jet_TLV,    Electron_TLV, Electron_jetIdx,    DRMAX_AK4);
-        Jet_matchesMuon        = AnaFunctions::getJetMatchesObjectVec(Jet_TLV,    Muon_TLV,     Muon_jetIdx,        DRMAX_AK4);
-        FatJet_matchesPhoton   = AnaFunctions::getJetMatchesObjectVec(FatJet_TLV, Photon_TLV,   DRMAX_AK8);
-        FatJet_matchesElectron = AnaFunctions::getJetMatchesObjectVec(FatJet_TLV, Electron_TLV, DRMAX_AK8);
-        FatJet_matchesMuon     = AnaFunctions::getJetMatchesObjectVec(FatJet_TLV, Muon_TLV,     DRMAX_AK8);
+        Jet_matchesPhoton      = AnaFunctions::getJetMatchesObjectVec(Jet_TLV,     Photon_TLV,    Photon_jetIdx,      DRMAX_AK4);
+        Jet_matchesElectron    = AnaFunctions::getJetMatchesObjectVec(Jet_TLV,     Electron_TLV,  Electron_jetIdx,    DRMAX_AK4);
+        Jet_matchesMuon        = AnaFunctions::getJetMatchesObjectVec(Jet_TLV,     Muon_TLV,      Muon_jetIdx,        DRMAX_AK4);
+        FatJet_matchesPhoton   = AnaFunctions::getJetMatchesObjectVec(FatJet_TLV,  Photon_TLV,    DRMAX_AK8);
+        FatJet_matchesElectron = AnaFunctions::getJetMatchesObjectVec(FatJet_TLV,  Electron_TLV,  DRMAX_AK8);
+        FatJet_matchesMuon     = AnaFunctions::getJetMatchesObjectVec(FatJet_TLV,  Muon_TLV,      DRMAX_AK8);
+        SB_matchesPhoton       = AnaFunctions::getJetMatchesObjectVec(SB_TLV,      Photon_TLV,    DRMAX_AK4);
+        SB_matchesElectron     = AnaFunctions::getJetMatchesObjectVec(SB_TLV,      Electron_TLV,  DRMAX_AK4);
+        SB_matchesMuon         = AnaFunctions::getJetMatchesObjectVec(SB_TLV,      Muon_TLV,      DRMAX_AK4);
 
     }
 
@@ -239,6 +250,7 @@ public:
                              "FatJetTLV",              
                              "SubJetTLV_AK8Matched",              
                              "FatJet_Stop0l",
+                             "FatJet_SF",
                              // from Nano AOD 
                              "FatJet_area",
                              // not a vector... cannot clean
@@ -279,6 +291,28 @@ public:
                              "FatJet_tau3",
                              "FatJet_tau4",
                            };
+        // soft bottom quark variables
+        SoftBottomVariables_ = {
+                                 "SBTLV",
+                                 "SB_dlen",
+                                 "SB_dlenSig",
+                                 "SB_DdotP",
+                                 "SB_dxy",
+                                 "SB_dxySig",
+                                 "SB_JetIdx",
+                                 "SB_chi2",
+                                 "SB_eta",
+                                 "SB_mass",
+                                 "SB_ndof",
+                                 "SB_phi",
+                                 "SB_pt",
+                                 "SB_ntracks",
+                                 "SB_Stop0l",
+                                 "SB_SF",
+                                 "SB_SFerr",
+                                 "SB_fastSF",
+                                 "SB_fastSFerr",
+                               };
     }
 
     ~CleanedJets(){}

--- a/Tools/GetVectors.h
+++ b/Tools/GetVectors.h
@@ -28,9 +28,10 @@ private:
     void generateGetVectors() 
     {
         // register vector<TLorentzVector>
-        registerTLV("Jet");         // AK4 jets
-        registerTLV("FatJet");      // AK8 jets 
-        registerTLV("SubJet");      // AK8 subjets
+        registerTLV("Jet");                     // AK4 jets
+        registerTLV("FatJet");                  // AK8 jets 
+        registerTLV("SubJet");                  // AK8 subjets
+        registerTLV("ResolvedTopCandidate");    // resolved tops
         
         // assign subjets to their AK8 jets
         // register vector<vector<TLorentzVector>> of subjets

--- a/Tools/GetVectors.h
+++ b/Tools/GetVectors.h
@@ -32,6 +32,7 @@ private:
         registerTLV("FatJet");                  // AK8 jets 
         registerTLV("SubJet");                  // AK8 subjets
         registerTLV("ResolvedTopCandidate");    // resolved tops
+        registerTLV("SB");                      // soft (low pt) bottom quarks
         
         // assign subjets to their AK8 jets
         // register vector<vector<TLorentzVector>> of subjets

--- a/Tools/RunTopTagger.h
+++ b/Tools/RunTopTagger.h
@@ -95,9 +95,9 @@ private:
         int nMergedTops             = 0;
         int nWs                     = 0;
         int nResolvedTops           = 0;
-        float MergedTopSF           = 1.0;
-        float WSF                   = 1.0;
-        float ResolvedTopSF         = 1.0;
+        float MergedTopTotalSF      = 1.0;
+        float WTotalSF              = 1.0;
+        float ResolvedTopTotalSF    = 1.0;
 
         //Select AK4 jets to use in tagger
         //When reading from the resolvedTopCandidate collection from nanoAOD you must pass ALL ak4 jets to ttUtility::ConstAK4Inputs below, 
@@ -141,13 +141,13 @@ private:
             {
                 if(FatJet_Stop0l[i] == 1)
                 {
-                    nMergedTops += 1;
-                    MergedTopSF *= FatJet_SF[i];
+                    nMergedTops         += 1;
+                    MergedTopTotalSF    *= FatJet_SF[i];
                 }
                 if(FatJet_Stop0l[i] == 2)
                 {
                     nWs         += 1;
-                    WSF         *= FatJet_SF[i];
+                    WTotalSF    *= FatJet_SF[i];
                 }
             }
         }
@@ -264,7 +264,7 @@ private:
             if (type == TopObject::Type::RESOLVED_TOP)      
             {
                 // scale factor
-                ResolvedTopSF *= top->getMCScaleFactor();
+                ResolvedTopTotalSF *= top->getMCScaleFactor();
                 ResolvedTopsTLV->push_back(top->p());
                 ResolvedTops_disc->push_back(top->getDiscriminator());
                 ResolvedTops_JetsMap->insert(std::make_pair(ResolvedTopIdx, temp));
@@ -292,17 +292,17 @@ private:
         }
         
         tr.registerDerivedVar("nMergedTops" + suffix_,              nMergedTops);
-        tr.registerDerivedVar("MergedTopSF" + suffix_,              MergedTopSF);
+        tr.registerDerivedVar("MergedTopTotalSF" + suffix_,         MergedTopTotalSF);
         tr.registerDerivedVec("MergedTopsTLV" + suffix_,            MergedTopsTLV);
         tr.registerDerivedVec("MergedTops_disc" + suffix_,          MergedTops_disc);
         tr.registerDerivedVec("MergedTops_JetsMap" + suffix_,       MergedTops_JetsMap);
         tr.registerDerivedVar("nWs" + suffix_,                      nWs);
-        tr.registerDerivedVar("WSF" + suffix_,                      WSF);
+        tr.registerDerivedVar("WTotalSF" + suffix_,                 WTotalSF);
         tr.registerDerivedVec("WTLV" + suffix_,                     WTLV);
         tr.registerDerivedVec("W_disc" + suffix_,                   W_disc);
         tr.registerDerivedVec("W_JetsMap" + suffix_,                W_JetsMap);
         tr.registerDerivedVar("nResolvedTops" + suffix_,            nResolvedTops);
-        tr.registerDerivedVar("ResolvedTopSF" + suffix_,            ResolvedTopSF);
+        tr.registerDerivedVar("ResolvedTopTotalSF" + suffix_,       ResolvedTopTotalSF);
         tr.registerDerivedVec("ResolvedTopsTLV" + suffix_,          ResolvedTopsTLV);
         tr.registerDerivedVec("ResolvedTops_disc" + suffix_,        ResolvedTops_disc);
         tr.registerDerivedVec("ResolvedTops_JetsMap" + suffix_,     ResolvedTops_JetsMap);

--- a/Tools/RunTopTagger.h
+++ b/Tools/RunTopTagger.h
@@ -220,7 +220,6 @@ private:
         bool printTops = false;
 
         if (printTops) std::cout << "----------------------------------------------------------------------" << std::endl;
-        //unsigned int topidx = 0;
         unsigned int MergedTopIdx   = 0;
         unsigned int WIdx           = 0;
         unsigned int ResolvedTopIdx = 0;
@@ -271,17 +270,12 @@ private:
                 ++ResolvedTopIdx;
             }
 
-            //++topidx;
         }
 
-        // number of tops
-        //use post-processed selections to calcualte number of merged tops and Ws 
-        //nMergedTops     = MergedTopsTLV->size();
-        //nWs             = WTLV->size();
+        // number of resolved tops
         nResolvedTops   = ResolvedTopsTLV->size();
         
         //print the number of tops found in the event 
-        //if (tops.size() > 1)
         if (printTops)
         {
             printf("tops.size() =  %ld ",      tops.size());

--- a/Tools/SB2018.h
+++ b/Tools/SB2018.h
@@ -60,6 +60,7 @@ int SB_lowdm(int njets, int nb, int nSV, float ISRpt, float bottompt_scalar_sum,
 //================================copy of SB_lowdm, just for name consistency=================================================
 int SBv2_lowdm(int njets, int nb, int nSV, float ISRpt, float bottompt_scalar_sum, float met) {return SB_lowdm(njets, nb, nSV, ISRpt, bottompt_scalar_sum, met);}
 int SBv3_lowdm(int njets, int nb, int nSV, float ISRpt, float bottompt_scalar_sum, float met) {return SB_lowdm(njets, nb, nSV, ISRpt, bottompt_scalar_sum, met);}
+int SBv4_lowdm(int njets, int nb, int nSV, float ISRpt, float bottompt_scalar_sum, float met) {return SB_lowdm(njets, nb, nSV, ISRpt, bottompt_scalar_sum, met);}
 
 //================================search bin v3 high dm=================================================
 int SBv3_highdm(float mtb, int njets, int nb, int ntop, int nw, int nres, float ht, float met)
@@ -215,6 +216,142 @@ int SBv3_highdm(float mtb, int njets, int nb, int ntop, int nw, int nres, float 
 	if (mtb >= 175 && nb >=3 && ntop ==0 && nw ==0 && nres ==2 && ht >= 1300 && met >= 550) return 201;
 	if (mtb >= 175 && nb >=3 && ntop+nres+nw >=3 && met >= 250 && met < 450) return 202;
 	if (mtb >= 175 && nb >=3 && ntop+nres+nw >=3 && met >= 450) return 203;
+	return -1;
+}
+
+//================================search bin v4 high dm=================================================
+int SBv4_highdm(float mtb, int njets, int nb, int ntop, int nw, int nres, float ht, float met)
+{
+	if (mtb < 175 && njets >=7 && nb ==1 && nres >=1 && met >= 250 && met < 300) return 53;
+	if (mtb < 175 && njets >=7 && nb ==1 && nres >=1 && met >= 300 && met < 400) return 54;
+	if (mtb < 175 && njets >=7 && nb ==1 && nres >=1 && met >= 400 && met < 500) return 55;
+	if (mtb < 175 && njets >=7 && nb ==1 && nres >=1 && met >= 500) return 56;
+	if (mtb < 175 && njets >=7 && nb >=2 && nres >=1 && met >= 250 && met < 300) return 57;
+	if (mtb < 175 && njets >=7 && nb >=2 && nres >=1 && met >= 300 && met < 400) return 58;
+	if (mtb < 175 && njets >=7 && nb >=2 && nres >=1 && met >= 400 && met < 500) return 59;
+	if (mtb < 175 && njets >=7 && nb >=2 && nres >=1 && met >= 500) return 60;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw ==0 && nres ==0 && ht >= 1000 && met >= 250 && met < 350) return 61;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw ==0 && nres ==0 && ht >= 1000 && met >= 350 && met < 450) return 62;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw ==0 && nres ==0 && ht >= 1000 && met >= 450 && met < 550) return 63;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw ==0 && nres ==0 && ht >= 1000 && met >= 550) return 64;
+	if (mtb >= 175 && nb >=2 && ntop ==0 && nw ==0 && nres ==0 && ht >= 1000 && met >= 250 && met < 350) return 65;
+	if (mtb >= 175 && nb >=2 && ntop ==0 && nw ==0 && nres ==0 && ht >= 1000 && met >= 350 && met < 450) return 66;
+	if (mtb >= 175 && nb >=2 && ntop ==0 && nw ==0 && nres ==0 && ht >= 1000 && met >= 450 && met < 550) return 67;
+	if (mtb >= 175 && nb >=2 && ntop ==0 && nw ==0 && nres ==0 && ht >= 1000 && met >= 550) return 68;
+	if (mtb >= 175 && nb ==1 && ntop >=1 && nw ==0 && nres ==0 && ht < 1000 && met >= 250 && met < 550) return 69;
+	if (mtb >= 175 && nb ==1 && ntop >=1 && nw ==0 && nres ==0 && ht < 1000 && met >= 550 && met < 650) return 70;
+	if (mtb >= 175 && nb ==1 && ntop >=1 && nw ==0 && nres ==0 && ht < 1000 && met >= 650) return 71;
+	if (mtb >= 175 && nb ==1 && ntop >=1 && nw ==0 && nres ==0 && ht >= 1000 && ht < 1500 && met >= 250 && met < 550) return 72;
+	if (mtb >= 175 && nb ==1 && ntop >=1 && nw ==0 && nres ==0 && ht >= 1000 && ht < 1500 && met >= 550 && met < 650) return 73;
+	if (mtb >= 175 && nb ==1 && ntop >=1 && nw ==0 && nres ==0 && ht >= 1000 && ht < 1500 && met >= 650) return 74;
+	if (mtb >= 175 && nb ==1 && ntop >=1 && nw ==0 && nres ==0 && ht >= 1500 && met >= 250 && met < 550) return 75;
+	if (mtb >= 175 && nb ==1 && ntop >=1 && nw ==0 && nres ==0 && ht >= 1500 && met >= 550 && met < 650) return 76;
+	if (mtb >= 175 && nb ==1 && ntop >=1 && nw ==0 && nres ==0 && ht >= 1500 && met >= 650) return 77;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw >=1 && nres ==0 && ht < 1300 && met >= 250 && met < 350) return 78;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw >=1 && nres ==0 && ht < 1300 && met >= 350 && met < 450) return 79;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw >=1 && nres ==0 && ht < 1300 && met >= 450) return 80;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw >=1 && nres ==0 && ht >= 1300 && met >= 250 && met < 350) return 81;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw >=1 && nres ==0 && ht >= 1300 && met >= 350 && met < 450) return 82;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw >=1 && nres ==0 && ht >= 1300 && met >= 450) return 83;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw ==0 && nres >=1 && ht < 1000 && met >= 250 && met < 350) return 84;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw ==0 && nres >=1 && ht < 1000 && met >= 350 && met < 450) return 85;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw ==0 && nres >=1 && ht < 1000 && met >= 450 && met < 550) return 86;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw ==0 && nres >=1 && ht < 1000 && met >= 550 && met < 650) return 87;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw ==0 && nres >=1 && ht < 1000 && met >= 650) return 88;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw ==0 && nres >=1 && ht >= 1000 && ht < 1500 && met >= 250 && met < 350) return 89;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw ==0 && nres >=1 && ht >= 1000 && ht < 1500 && met >= 350 && met < 450) return 90;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw ==0 && nres >=1 && ht >= 1000 && ht < 1500 && met >= 450 && met < 550) return 91;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw ==0 && nres >=1 && ht >= 1000 && ht < 1500 && met >= 550 && met < 650) return 92;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw ==0 && nres >=1 && ht >= 1000 && ht < 1500 && met >= 650) return 93;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw ==0 && nres >=1 && ht >= 1500 && met >= 250 && met < 350) return 94;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw ==0 && nres >=1 && ht >= 1500 && met >= 350 && met < 450) return 95;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw ==0 && nres >=1 && ht >= 1500 && met >= 450 && met < 550) return 96;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw ==0 && nres >=1 && ht >= 1500 && met >= 550 && met < 650) return 97;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw ==0 && nres >=1 && ht >= 1500 && met >= 650) return 98;
+	if (mtb >= 175 && nb ==1 && ntop >=1 && nw >=1 && nres ==0 && met >= 250 && met < 550) return 99;
+	if (mtb >= 175 && nb ==1 && ntop >=1 && nw >=1 && nres ==0 && met >= 550) return 100;
+	if (mtb >= 175 && nb ==1 && ntop >=1 && nw ==0 && nres >=1 && met >= 250 && met < 550) return 101;
+	if (mtb >= 175 && nb ==1 && ntop >=1 && nw ==0 && nres >=1 && met >= 550) return 102;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw >=1 && nres >=1 && met >= 250 && met < 550) return 103;
+	if (mtb >= 175 && nb ==1 && ntop ==0 && nw >=1 && nres >=1 && met >= 550) return 104;
+	if (mtb >= 175 && nb ==2 && ntop ==1 && nw ==0 && nres ==0 && ht < 1000 && met >= 250 && met < 550) return 105;
+	if (mtb >= 175 && nb ==2 && ntop ==1 && nw ==0 && nres ==0 && ht < 1000 && met >= 550 && met < 650) return 106;
+	if (mtb >= 175 && nb ==2 && ntop ==1 && nw ==0 && nres ==0 && ht < 1000 && met >= 650) return 107;
+	if (mtb >= 175 && nb ==2 && ntop ==1 && nw ==0 && nres ==0 && ht >= 1000 && ht < 1500 && met >= 250 && met < 550) return 108;
+	if (mtb >= 175 && nb ==2 && ntop ==1 && nw ==0 && nres ==0 && ht >= 1000 && ht < 1500 && met >= 550 && met < 650) return 109;
+	if (mtb >= 175 && nb ==2 && ntop ==1 && nw ==0 && nres ==0 && ht >= 1000 && ht < 1500 && met >= 650) return 110;
+	if (mtb >= 175 && nb ==2 && ntop ==1 && nw ==0 && nres ==0 && ht >= 1500 && met >= 250 && met < 550) return 111;
+	if (mtb >= 175 && nb ==2 && ntop ==1 && nw ==0 && nres ==0 && ht >= 1500 && met >= 550 && met < 650) return 112;
+	if (mtb >= 175 && nb ==2 && ntop ==1 && nw ==0 && nres ==0 && ht >= 1500 && met >= 650) return 113;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==1 && nres ==0 && ht < 1300 && met >= 250 && met < 350) return 114;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==1 && nres ==0 && ht < 1300 && met >= 350 && met < 450) return 115;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==1 && nres ==0 && ht < 1300 && met >= 450) return 116;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==1 && nres ==0 && ht >= 1300 && met >= 250 && met < 350) return 117;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==1 && nres ==0 && ht >= 1300 && met >= 350 && met < 450) return 118;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==1 && nres ==0 && ht >= 1300 && met >= 450) return 119;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==0 && nres ==1 && ht < 1000 && met >= 250 && met < 350) return 120;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==0 && nres ==1 && ht < 1000 && met >= 350 && met < 450) return 121;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==0 && nres ==1 && ht < 1000 && met >= 450 && met < 550) return 122;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==0 && nres ==1 && ht < 1000 && met >= 550 && met < 650) return 123;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==0 && nres ==1 && ht < 1000 && met >= 650) return 124;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==0 && nres ==1 && ht >= 1000 && ht < 1500 && met >= 250 && met < 350) return 125;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==0 && nres ==1 && ht >= 1000 && ht < 1500 && met >= 350 && met < 450) return 126;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==0 && nres ==1 && ht >= 1000 && ht < 1500 && met >= 450 && met < 550) return 127;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==0 && nres ==1 && ht >= 1000 && ht < 1500 && met >= 550 && met < 650) return 128;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==0 && nres ==1 && ht >= 1000 && ht < 1500 && met >= 650) return 129;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==0 && nres ==1 && ht >= 1500 && met >= 250 && met < 350) return 130;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==0 && nres ==1 && ht >= 1500 && met >= 350 && met < 450) return 131;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==0 && nres ==1 && ht >= 1500 && met >= 450 && met < 550) return 132;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==0 && nres ==1 && ht >= 1500 && met >= 550 && met < 650) return 133;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==0 && nres ==1 && ht >= 1500 && met >= 650) return 134;
+	if (mtb >= 175 && nb ==2 && ntop ==1 && nw ==1 && nres ==0 && met >= 250 && met < 550) return 135;
+	if (mtb >= 175 && nb ==2 && ntop ==1 && nw ==1 && nres ==0 && met >= 550) return 136;
+	if (mtb >= 175 && nb ==2 && ntop ==1 && nw ==0 && nres ==1 && ht < 1300 && met >= 250 && met < 350) return 137;
+	if (mtb >= 175 && nb ==2 && ntop ==1 && nw ==0 && nres ==1 && ht < 1300 && met >= 350 && met < 450) return 138;
+	if (mtb >= 175 && nb ==2 && ntop ==1 && nw ==0 && nres ==1 && ht < 1300 && met >= 450) return 139;
+	if (mtb >= 175 && nb ==2 && ntop ==1 && nw ==0 && nres ==1 && ht >= 1300 && met >= 250 && met < 350) return 140;
+	if (mtb >= 175 && nb ==2 && ntop ==1 && nw ==0 && nres ==1 && ht >= 1300 && met >= 350 && met < 450) return 141;
+	if (mtb >= 175 && nb ==2 && ntop ==1 && nw ==0 && nres ==1 && ht >= 1300 && met >= 450) return 142;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==1 && nres ==1 && met >= 250 && met < 550) return 143;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==1 && nres ==1 && met >= 550) return 144;
+	if (mtb >= 175 && nb ==2 && ntop ==2 && nw ==0 && nres ==0 && met >= 250 && met < 450) return 145;
+	if (mtb >= 175 && nb ==2 && ntop ==2 && nw ==0 && nres ==0 && met >= 450) return 146;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==2 && nres ==0 && met >= 250) return 147;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==0 && nres ==2 && ht < 1300 && met >= 250 && met < 450) return 148;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==0 && nres ==2 && ht < 1300 && met >= 450) return 149;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==0 && nres ==2 && ht >= 1300 && met >= 250 && met < 450) return 150;
+	if (mtb >= 175 && nb ==2 && ntop ==0 && nw ==0 && nres ==2 && ht >= 1300 && met >= 450) return 151;
+	if (mtb >= 175 && nb ==2 && ntop+nres+nw >=3 && met >= 250) return 152;
+	if (mtb >= 175 && nb >=3 && ntop ==1 && nw ==0 && nres ==0 && ht < 1000 && met >= 250 && met < 350) return 153;
+	if (mtb >= 175 && nb >=3 && ntop ==1 && nw ==0 && nres ==0 && ht < 1000 && met >= 350 && met < 550) return 154;
+	if (mtb >= 175 && nb >=3 && ntop ==1 && nw ==0 && nres ==0 && ht < 1000 && met >= 550) return 155;
+	if (mtb >= 175 && nb >=3 && ntop ==1 && nw ==0 && nres ==0 && ht >= 1000 && ht < 1500 && met >= 250 && met < 350) return 156;
+	if (mtb >= 175 && nb >=3 && ntop ==1 && nw ==0 && nres ==0 && ht >= 1000 && ht < 1500 && met >= 350 && met < 550) return 157;
+	if (mtb >= 175 && nb >=3 && ntop ==1 && nw ==0 && nres ==0 && ht >= 1000 && ht < 1500 && met >= 550) return 158;
+	if (mtb >= 175 && nb >=3 && ntop ==1 && nw ==0 && nres ==0 && ht >= 1500 && met >= 250 && met < 350) return 159;
+	if (mtb >= 175 && nb >=3 && ntop ==1 && nw ==0 && nres ==0 && ht >= 1500 && met >= 350 && met < 550) return 160;
+	if (mtb >= 175 && nb >=3 && ntop ==1 && nw ==0 && nres ==0 && ht >= 1500 && met >= 550) return 161;
+	if (mtb >= 175 && nb >=3 && ntop ==0 && nw ==1 && nres ==0 && met >= 250 && met < 350) return 162;
+	if (mtb >= 175 && nb >=3 && ntop ==0 && nw ==1 && nres ==0 && met >= 350 && met < 550) return 163;
+	if (mtb >= 175 && nb >=3 && ntop ==0 && nw ==1 && nres ==0 && met >= 550) return 164;
+	if (mtb >= 175 && nb >=3 && ntop ==0 && nw ==0 && nres ==1 && ht < 1000 && met >= 250 && met < 350) return 165;
+	if (mtb >= 175 && nb >=3 && ntop ==0 && nw ==0 && nres ==1 && ht < 1000 && met >= 350 && met < 550) return 166;
+	if (mtb >= 175 && nb >=3 && ntop ==0 && nw ==0 && nres ==1 && ht < 1000 && met >= 550) return 167;
+	if (mtb >= 175 && nb >=3 && ntop ==0 && nw ==0 && nres ==1 && ht >= 1000 && ht < 1500 && met >= 250 && met < 350) return 168;
+	if (mtb >= 175 && nb >=3 && ntop ==0 && nw ==0 && nres ==1 && ht >= 1000 && ht < 1500 && met >= 350 && met < 550) return 169;
+	if (mtb >= 175 && nb >=3 && ntop ==0 && nw ==0 && nres ==1 && ht >= 1000 && ht < 1500 && met >= 550) return 170;
+	if (mtb >= 175 && nb >=3 && ntop ==0 && nw ==0 && nres ==1 && ht >= 1500 && met >= 250 && met < 350) return 171;
+	if (mtb >= 175 && nb >=3 && ntop ==0 && nw ==0 && nres ==1 && ht >= 1500 && met >= 350 && met < 550) return 172;
+	if (mtb >= 175 && nb >=3 && ntop ==0 && nw ==0 && nres ==1 && ht >= 1500 && met >= 550) return 173;
+	if (mtb >= 175 && nb >=3 && ntop ==1 && nw ==1 && nres ==0 && met >= 250) return 174;
+	if (mtb >= 175 && nb >=3 && ntop ==1 && nw ==0 && nres ==1 && met >= 250 && met < 350) return 175;
+	if (mtb >= 175 && nb >=3 && ntop ==1 && nw ==0 && nres ==1 && met >= 350) return 176;
+	if (mtb >= 175 && nb >=3 && ntop ==0 && nw ==1 && nres ==1 && met >= 250) return 177;
+	if (mtb >= 175 && nb >=3 && ntop ==2 && nw ==0 && nres ==0 && met >= 250) return 178;
+	if (mtb >= 175 && nb >=3 && ntop ==0 && nw ==2 && nres ==0 && met >= 250) return 179;
+	if (mtb >= 175 && nb >=3 && ntop ==0 && nw ==0 && nres ==2 && met >= 250 && met < 350) return 180;
+	if (mtb >= 175 && nb >=3 && ntop ==0 && nw ==0 && nres ==2 && met >= 350) return 181;
+	if (mtb >= 175 && nb >=3 && ntop+nres+nw >=3 && met >= 250) return 182;
 	return -1;
 }
 

--- a/Tools/SusyUtility.cc
+++ b/Tools/SusyUtility.cc
@@ -18,7 +18,6 @@ using json = nlohmann::json;
 
 namespace SusyUtility
 {
-    // be careful with repeated funtion name: split() is already defined in "../../json/single_include/nlohmann/json.hpp"
     void splitString(const std::string &s, const char& delim, std::vector<std::string>& result) {
         std::stringstream ss;
         ss.str(s);

--- a/Tools/SusyUtility.cc
+++ b/Tools/SusyUtility.cc
@@ -131,11 +131,23 @@ namespace SusyUtility
         std::ifstream i(fileName);
         json j;
         i >> j;
-        // print json file
-        std::cout << title << std::endl;
+
+        // invert map
+        std::map<int, std::string> invMap;
+
         for (const auto& element : j[key].items())
         {
-            std::cout << element.key() << " : " << element.value() << std::endl;
+            std::string k = element.key();
+            int v = std::stoi(std::string(element.value())); 
+            invMap[v] = k;
+        }
+        
+        // print json file
+        int nBins = invMap.size();
+        std::cout << title << " : " << nBins << " bins" << std::endl;
+        for (int i = 0; i < nBins; ++i)
+        {
+            std::cout << i << " : " << invMap[i] << std::endl;
         }
     }
 }

--- a/Tools/SusyUtility.cc
+++ b/Tools/SusyUtility.cc
@@ -4,6 +4,7 @@
 
 // utility functions
 #include "SusyAnaTools/Tools/SusyUtility.h"
+#include <fstream>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -11,9 +12,14 @@
 #include <iterator>
 #include <regex>
 
+// Repo for json.hpp: https://github.com/nlohmann/json/tree/master
+#include "../../json/single_include/nlohmann/json.hpp"
+using json = nlohmann::json;
+
 namespace SusyUtility
 {
-    void split(const std::string &s, const char& delim, std::vector<std::string>& result) {
+    // be careful with repeated funtion name: split() is already defined in "../../json/single_include/nlohmann/json.hpp"
+    void splitString(const std::string &s, const char& delim, std::vector<std::string>& result) {
         std::stringstream ss;
         ss.str(s);
         std::string item;
@@ -52,14 +58,14 @@ namespace SusyUtility
     
     // return vector of strings given names separated by deliminator, e.g. "electron;muon" ---> {"electron", "muon"} 
     std::vector<std::string> getVecFromString(const std::string &s, const char& delim) {
-        std::vector<std::string> splitString;
+        std::vector<std::string> mySplitString;
         if (!delim)
         {
             std::cout << "ERROR in getVecFromString(): please provide string (s) and char (delim)" << std::endl;
-            return splitString;
+            return mySplitString;
         }
-        split(s, delim, splitString);
-        return splitString;
+        splitString(s, delim, mySplitString);
+        return mySplitString;
     }
     
     // get cut levels
@@ -118,4 +124,21 @@ namespace SusyUtility
 
         return output;
     }
+    
+    void printJson(const std::string& fileName, const std::string& key, const std::string& title)
+    {
+        // read json file
+        std::ifstream i(fileName);
+        json j;
+        i >> j;
+        // print json file
+        std::cout << title << std::endl;
+        for (const auto& element : j[key].items())
+        {
+            std::cout << element.key() << " : " << element.value() << std::endl;
+        }
+    }
 }
+
+
+

--- a/Tools/SusyUtility.h
+++ b/Tools/SusyUtility.h
@@ -17,7 +17,7 @@
 
 namespace SusyUtility
 {
-    void split(const std::string &s, const char& delim, std::vector<std::string>& result);
+    void splitString(const std::string &s, const char& delim, std::vector<std::string>& result);
     
     template<typename T1, typename T2> 
     bool greaterThan(const std::pair<T1,T2>& p1, const std::pair<T1,T2>& p2)

--- a/Tools/SusyUtility.h
+++ b/Tools/SusyUtility.h
@@ -38,12 +38,14 @@ namespace SusyUtility
     bool lessThan(const std::pair<TLorentzVector,unsigned int>& p1, const std::pair<TLorentzVector,unsigned int>& p2);
     
     // return vector of strings given names separated by deliminator, e.g. "electron;muon" ---> {"electron", "muon"} 
-    std::vector<std::string> getVecFromString(const std::string &s, const char& delim);
+    std::vector<std::string> getVecFromString(const std::string& s, const char& delim);
     // get cut levels, e.g. {"", "cut1", "cut2", "cut3"} ---> {"", "cut1", "cut1;cut2", "cut1;cut2;cut3"}
     std::vector<std::string> getCutLevels(const std::vector<std::string> cuts);
     // functions to parse cuts, e.g. "NBeq0_NSVeq0" ---> ";nBottoms_drLeptonCleaned=0;nSoftBottoms_drLeptonCleaned=0"
     // https://stackoverflow.com/questions/3418231/replace-part-of-a-string-with-another-string
     std::string parseCuts(std::string& input, std::map<std::string, std::string> var_map);
+
+    void printJson(const std::string& fileName, const std::string& key, const std::string& title);
 
 }
 

--- a/Tools/baselineDef.cc
+++ b/Tools/baselineDef.cc
@@ -584,8 +584,8 @@ void BaselineVessel::PassBaseline()
   
   //SUS-16-049, low dm, ISR cut
   // see GetISRJetIdx() and CalcISRJetVars() for details
-  bool SAT_Pass_ISR         = (ISRJetPt >= 200);
-  bool SAT_Pass_ISR_Tight   = (ISRJetPt >= 300);
+  bool SAT_Pass_ISR_Loose   = (ISRJetPt >= 200);
+  bool SAT_Pass_ISR         = (ISRJetPt >= 300);
   bool SAT_Pass_S_MET       = (S_met >= 10);
   
   // ----------------------- // 
@@ -739,7 +739,7 @@ void BaselineVessel::PassBaseline()
                      && nMergedTops == 0
                      && nResolvedTops == 0
                      && nWs == 0
-                     && SAT_Pass_ISR_Tight
+                     && SAT_Pass_ISR
                      && SAT_Pass_S_MET
                      && SAT_Pass_MTB_LowDM
                    );      
@@ -769,13 +769,14 @@ void BaselineVessel::PassBaseline()
                          && SAT_Pass_NJets
                       );
   //baseline for SUS-16-049 low dm plus HT cut
+  //Use SAT_Pass_ISR_Loose
   bool SAT_Pass_lowDM_mid_dPhi = (
                         SAT_Pass_Baseline_no_dPhi
                      && SAT_Pass_mid_dPhiMETLowDM 
                      && nMergedTops == 0
                      && nResolvedTops == 0
                      && nWs == 0
-                     && SAT_Pass_ISR
+                     && SAT_Pass_ISR_Loose
                      && SAT_Pass_S_MET
                      && SAT_Pass_MTB_LowDM
                    );      
@@ -802,7 +803,7 @@ void BaselineVessel::PassBaseline()
                      && SAT_Pass_mid_dPhiMETLowDM 
                      && nMergedTops == 0
                      && nWs == 0
-                     && SAT_Pass_ISR
+                     && SAT_Pass_ISR_Loose
                      && SAT_Pass_S_MET
                      && SAT_Pass_MTB_LowDM
                    );      
@@ -828,7 +829,7 @@ void BaselineVessel::PassBaseline()
                      && SAT_Pass_mid_dPhiMETLowDM 
                      && nMergedTops == 0
                      && nWs == 0
-                     && SAT_Pass_ISR
+                     && SAT_Pass_ISR_Loose
                      && SAT_Pass_S_MET
                      && SAT_Pass_MTB_LowDM
                    );      

--- a/Tools/baselineDef.cc
+++ b/Tools/baselineDef.cc
@@ -559,7 +559,7 @@ void BaselineVessel::PassBaseline()
   bool Pass_EventFilter                             = tr->getVar<bool>("Pass_EventFilter");
   bool Pass_MET                                     = tr->getVar<bool>("Pass_MET");
   bool Pass_HT                                      = tr->getVar<bool>("Pass_HT");
-  bool Pass_NJets                                   = tr->getVar<bool>("Pass_NJets20");
+  bool Pass_NJets                                   = tr->getVar<bool>("Pass_NJets30");
   bool Pass_dPhiMETLowDM                            = tr->getVar<bool>("Pass_dPhiMETLowDM");
   bool Pass_LeptonVeto                              = tr->getVar<bool>("Pass_LeptonVeto");
   

--- a/Tools/baselineDef.cc
+++ b/Tools/baselineDef.cc
@@ -473,6 +473,7 @@ void BaselineVessel::PassBaseline()
     {
       genWeightNormalized = genWeightNormalized / fabs(genWeightNormalized);
     }
+    //printf("genWeight: %f, genWeightNormalized: %f\n", genWeight, genWeightNormalized);
     tr->registerDerivedVar("genWeightNormalized" + firstSpec, genWeightNormalized);
   }
 

--- a/Tools/baselineDef.cc
+++ b/Tools/baselineDef.cc
@@ -525,23 +525,17 @@ void BaselineVessel::PassBaseline()
   
   // variables for SAT_Pass_lowDM and SAT_Pass_highDM
   const auto& event                 = tr->getVar<unsigned long long>("event");
-  const auto& nMergedTops           = tr->getVar<int>(UseCleanedJetsVar("nMergedTops"));
-  const auto& nWs                   = tr->getVar<int>(UseCleanedJetsVar("nWs"));
-  const auto& nResolvedTops         = tr->getVar<int>(UseCleanedJetsVar("nResolvedTops"));
-  const auto& nBottoms              = tr->getVar<int>(UseCleanedJetsVar("nBottoms"));
   const auto& mtb                   = tr->getVar<float>(UseCleanedJetsVar("mtb"));
   const auto& ptb                   = tr->getVar<float>(UseCleanedJetsVar("ptb"));
   const auto& ISRJetPt              = tr->getVar<float>(UseCleanedJetsVar("ISRJetPt"));
   const auto& ISRJetIdx             = tr->getVar<int>(UseCleanedJetsVar("ISRJetIdx"));
-  const auto& MergedTopsTLV         = tr->getVec<TLorentzVector>(UseCleanedJetsVar("MergedTopsTLV"));
-  const auto& MergedTops_disc       = tr->getVec<double>(UseCleanedJetsVar("MergedTops_disc"));
-  const auto& MergedTops_JetsMap    = tr->getMap<int, std::vector<TLorentzVector>>(UseCleanedJetsVar("MergedTops_JetsMap"));
-  const auto& WTLV                  = tr->getVec<TLorentzVector>(UseCleanedJetsVar("WTLV"));
-  const auto& W_disc                = tr->getVec<double>(UseCleanedJetsVar("W_disc"));
-  const auto& W_JetsMap             = tr->getMap<int, std::vector<TLorentzVector>>(UseCleanedJetsVar("W_JetsMap"));
-  const auto& ResolvedTopsTLV       = tr->getVec<TLorentzVector>(UseCleanedJetsVar("ResolvedTopsTLV"));
-  const auto& ResolvedTops_disc     = tr->getVec<double>(UseCleanedJetsVar("ResolvedTops_disc"));
-  const auto& ResolvedTops_JetsMap  = tr->getMap<int, std::vector<TLorentzVector>>(UseCleanedJetsVar("ResolvedTops_JetsMap"));
+  const auto& nBottoms              = tr->getVar<int>(UseCleanedJetsVar("nBottoms"));
+  const auto& nMergedTops           = tr->getVar<int>(UseCleanedJetsVar("nMergedTops"));
+  const auto& nWs                   = tr->getVar<int>(UseCleanedJetsVar("nWs"));
+  const auto& nResolvedTops         = tr->getVar<int>(UseCleanedJetsVar("nResolvedTops"));
+  const auto& MergedTopTotalSF      = tr->getVar<float>(UseCleanedJetsVar("MergedTopTotalSF"));
+  const auto& WTotalSF              = tr->getVar<float>(UseCleanedJetsVar("WTotalSF"));
+  const auto& ResolvedTopTotalSF    = tr->getVar<float>(UseCleanedJetsVar("ResolvedTopTotalSF"));
   const auto* ttr                   = tr->getVar<TopTaggerResults*>("ttr");
   // variables from post-processing
   const auto& ResolvedTopCandidateTLV               = tr->getVec<TLorentzVector>("ResolvedTopCandidateTLV");
@@ -867,10 +861,13 @@ void BaselineVessel::PassBaseline()
   //if (SAT_Pass_lowDM != Pass_lowDM && firstSpec.empty())
   //if (event == 1401471244)
   bool topDifference = bool(Stop0l_nTop != nMergedTops || Stop0l_nResolved != nResolvedTops || Stop0l_nW != nWs);
+  int totalTopsWs = nMergedTops + nResolvedTops + nWs; 
   //if (topDifference && firstSpec.empty())
+  //if (totalTopsWs && firstSpec.empty())
   if (verbose)
   {
-    printf("WARNING: Difference in number of tops and/or Ws found!\n");
+    //printf("WARNING: Difference in number of tops and/or Ws found!\n");
+    printf("-----------------------------------------------------------------------------------------\n");
     printf("firstSpec: %s; CMS event: %d ntuple event: %d\n", firstSpec.c_str(), event, tr->getEvtNum());
     printf("Pass_lowDM = %d and SAT_Pass_lowDM = %d\n", Pass_lowDM, SAT_Pass_lowDM);
     printf("\thui_Pass_LeptonVeto   = %d and caleb_SAT_Pass_LeptonVeto    = %d\n", Pass_LeptonVeto, SAT_Pass_LeptonVeto);
@@ -886,6 +883,10 @@ void BaselineVessel::PassBaseline()
     printf("\thui_Stop0l_nTop       = %d and caleb_nMergedTops            = %d\n", Stop0l_nTop, nMergedTops);
     printf("\thui_Stop0l_nW         = %d and caleb_nWs                    = %d\n", Stop0l_nW, nWs);
     printf("\thui_Stop0l_nResolved  = %d and caleb_nResolvedTops          = %d\n", Stop0l_nResolved, nResolvedTops);
+    printf("\tcaleb_MergedTopTotalSF    = %f\n", MergedTopTotalSF);
+    printf("\tcaleb_WTotalSF            = %f\n", WTotalSF);
+    printf("\tcaleb_ResolvedTopTotalSF  = %f\n", ResolvedTopTotalSF);
+    
     printf("------------- hui tops -------------\n");
     for (int i = 0; i < ResolvedTopCandidateTLV.size(); ++i)
     {
@@ -905,42 +906,6 @@ void BaselineVessel::PassBaseline()
         }
         
     }
-
-
-//    for (int i = 0; i < MergedTopsTLV.size(); ++i)
-//    {
-//        const auto& jets_ = MergedTops_JetsMap.at(i);
-//        printf("\tMergedTop %d: (pt=%f, eta=%f, phi=%f, mass=%f), disc=%f\n", i, MergedTopsTLV[i].Pt(), MergedTopsTLV[i].Eta(), MergedTopsTLV[i].Phi(), MergedTopsTLV[i].M(), MergedTops_disc[i]);
-//        int j = 0;
-//        for (const auto& jet : jets_)
-//        {
-//            printf("\t\tjet %d: (pt=%f, eta=%f, phi=%f, mass=%f)\n", i, jet.Pt(), jet.Eta(), jet.Phi(), jet.M());
-//            ++j;
-//        }
-//    }
-//    for (int i = 0; i < WTLV.size(); ++i)
-//    {
-//        const auto& jets_ = W_JetsMap.at(i);
-//        printf("\tW %d: (pt=%f, eta=%f, phi=%f, mass=%f), disc=%f\n", i, WTLV[i].Pt(), WTLV[i].Eta(), WTLV[i].Phi(), WTLV[i].M(), W_disc[i]);
-//        int j = 0;
-//        for (const auto& jet : jets_)
-//        {
-//            printf("\t\tjet %d: (pt=%f, eta=%f, phi=%f, mass=%f)\n", i, jet.Pt(), jet.Eta(), jet.Phi(), jet.M());
-//            ++j;
-//        }
-//    }
-//    for (int i = 0; i < ResolvedTopsTLV.size(); ++i)
-//    {
-//        const auto& jets_ = ResolvedTops_JetsMap.at(i);
-//        printf("\tResolvedTop %d: (pt=%f, eta=%f, phi=%f, mass=%f), disc=%f\n", i, ResolvedTopsTLV[i].Pt(), ResolvedTopsTLV[i].Eta(), ResolvedTopsTLV[i].Phi(), ResolvedTopsTLV[i].M(), ResolvedTops_disc[i]);
-//        int j = 0;
-//        for (const auto& jet : jets_)
-//        {
-//            printf("\t\tjet %d: (pt=%f, eta=%f, phi=%f, mass=%f)\n", i, jet.Pt(), jet.Eta(), jet.Phi(), jet.M());
-//            ++j;
-//        }
-//    }
-
     
     if (verbose)
     {

--- a/Tools/condor/multiBatchList.py
+++ b/Tools/condor/multiBatchList.py
@@ -1,0 +1,40 @@
+# multiBatchList.py
+
+# run batchList.py on multiple directories for a config files
+
+from samples import SampleSet
+import optparse 
+import os
+import sys
+import re
+
+# get list of unique directories
+# strip off prefix and file name
+def getDirs(sampleSetsFile, prefix):
+    dirs = []
+    ss = SampleSet(sampleSetsFile)
+    for ds in ss.sampleSetList():
+        path = ds[1]
+        path = re.sub(prefix, "", path) 
+        path = re.sub("/[A-Za-z0-9_.-]*\.txt$", "", path) 
+        if path not in dirs:
+            dirs.append(path)
+            #print path
+    return dirs
+
+if __name__ == "__main__":
+
+    parser = optparse.OptionParser("usage: %prog [options]\n")
+    parser.add_option ('-s',      dest='sampleSetsFile',       type='string',    default = "",      help="Sample sets config file")
+    options, args = parser.parse_args()
+    sampleSetsFile = options.sampleSetsFile
+
+    if not os.path.exists(sampleSetsFile):
+        print "The sample sets config file \"{0}\" does not exist.".format(sampleSetsFile)
+        exit(1)
+
+    dirs = getDirs(sampleSetsFile, "/eos/uscms")
+    for d in dirs:
+        print d
+
+    

--- a/Tools/condor/multiBatchList.py
+++ b/Tools/condor/multiBatchList.py
@@ -3,7 +3,9 @@
 # run batchList.py on multiple directories for a config files
 
 from samples import SampleSet
+import argparse
 import optparse 
+import subprocess
 import os
 import sys
 import re
@@ -23,11 +25,13 @@ def getDirs(sampleSetsFile, prefix):
     return dirs
 
 if __name__ == "__main__":
-
-    parser = optparse.OptionParser("usage: %prog [options]\n")
-    parser.add_option ('-s',      dest='sampleSetsFile',       type='string',    default = "",      help="Sample sets config file")
-    options, args = parser.parse_args()
-    sampleSetsFile = options.sampleSetsFile
+    # options
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("--sampleSetsFile", "-s",   default = "",                           help="Sample sets config file")
+    parser.add_argument("--run",            "-r",   default = False, action = "store_true", help="run batchList.py on all directories")
+    options         = parser.parse_args()
+    sampleSetsFile  = options.sampleSetsFile
+    run             = options.run 
 
     if not os.path.exists(sampleSetsFile):
         print "The sample sets config file \"{0}\" does not exist.".format(sampleSetsFile)
@@ -35,6 +39,12 @@ if __name__ == "__main__":
 
     dirs = getDirs(sampleSetsFile, "/eos/uscms")
     for d in dirs:
-        print d
+        if run:
+            command = "python batchList.py -d {0} -l -c".format(d)
+            print command
+            subprocess.call(command, shell=True)
+        else:
+            print d
+
 
     

--- a/Tools/condor/nEvtsCondorSubmit.py
+++ b/Tools/condor/nEvtsCondorSubmit.py
@@ -1,15 +1,14 @@
 #!/cvmfs/cms.cern.ch/slc6_amd64_gcc491/cms/cmssw/CMSSW_7_4_8/external/slc6_amd64_gcc491/bin/python
 ####!${SRT_CMSSW_RELEASE_BASE_SCRAMRTDEL}/external/${SCRAM_ARCH}/bin/python
 
-import sys
-import os
-from os import system, environ
-sys.path = [environ["CMSSW_BASE"] + "/src/SusyAnaTools/Tools/condor/",] + sys.path
-
 from samples import SampleSet
 import optparse 
 import subprocess
 import datetime
+import sys
+import os
+from os import system, environ
+sys.path = [environ["CMSSW_BASE"] + "/src/SusyAnaTools/Tools/condor/",] + sys.path
 
 # options
 parser = optparse.OptionParser("usage: %prog [options]\n")

--- a/Tools/condor/nEvtsCondorSubmit.py
+++ b/Tools/condor/nEvtsCondorSubmit.py
@@ -59,7 +59,7 @@ def makeExeAndFriendsTarrball(filestoTransfer, fname):
 
 submitFile = submitFileTT
 fileParts = [submitFile]
-sc = SampleSet(sampleSetsFile)
+ss = SampleSet(sampleSetsFile)
 
 # make directory for condor submission
 now = datetime.datetime.now()
@@ -76,7 +76,7 @@ if True:
 exeName = "nEvts"
 makeExeAndFriendsTarrball(filestoTransferTT, "TT")
 
-for ds in sc.sampleSetList():
+for ds in ss.sampleSetList():
     dsn = ds[0]
 
     fileParts.append("Arguments = %s $ENV(CMSSW_VERSION) %s\n"%(dsn, sampleSetsFile))

--- a/Tools/condor/updateSamples.py
+++ b/Tools/condor/updateSamples.py
@@ -9,7 +9,6 @@
 import argparse
 import re
 from shutil import copyfile
-
 from samples import SampleSet
 from nEvts import getNEvts
 


### PR DESCRIPTION
New search bins SBv4 from Hui (@wang-hui)

Calcualte normalized genWeight to use as overall sign ±1 when filling histograms

Lepton / photon clean soft bottom quarks

Calculate total event scale factors from per object scale factors for selected objects
- MergedTopTotalSF
- WTotalSF
- ResolvedTopTotalSF
- SoftBottomTotalSF