### PR TITLE
HEM Veto Weight

### DIFF
--- a/Tools/GetVectors.h
+++ b/Tools/GetVectors.h
@@ -28,11 +28,13 @@ private:
     void generateGetVectors() 
     {
         // register vector<TLorentzVector>
-        registerTLV("Jet");                     // AK4 jets
-        registerTLV("FatJet");                  // AK8 jets 
-        registerTLV("SubJet");                  // AK8 subjets
-        registerTLV("ResolvedTopCandidate");    // resolved tops
-        registerTLV("SB");                      // soft (low pt) bottom quarks
+        registerTLV("Jet");                             // AK4 jets
+        registerTLV("FatJet");                          // AK8 jets 
+        registerTLV("SubJet");                          // AK8 subjets
+        registerTLV("ResolvedTopCandidate");            // resolved tops
+        registerTLV("ResolvedTopCandidate_JESUp");      // resolved tops JES up
+        registerTLV("ResolvedTopCandidate_JESDown");    // resolved tops JES down
+        registerTLV("SB");                              // soft (low pt) bottom quarks
         
         // assign subjets to their AK8 jets
         // register vector<vector<TLorentzVector>> of subjets

--- a/Tools/GetVectors.h
+++ b/Tools/GetVectors.h
@@ -32,8 +32,6 @@ private:
         registerTLV("FatJet");                          // AK8 jets 
         registerTLV("SubJet");                          // AK8 subjets
         registerTLV("ResolvedTopCandidate");            // resolved tops
-        registerTLV("ResolvedTopCandidate_JESUp");      // resolved tops JES up
-        registerTLV("ResolvedTopCandidate_JESDown");    // resolved tops JES down
         registerTLV("SB");                              // soft (low pt) bottom quarks
         
         // assign subjets to their AK8 jets
@@ -49,6 +47,8 @@ private:
             // only apply JES systematics to MC, not Data
             registerTLV("Jet", "_jesTotalUp");      // jec up (for systematics)
             registerTLV("Jet", "_jesTotalDown");    // jec down (for systematics)
+            registerTLV("ResolvedTopCandidate_JESUp");      // resolved tops JES up
+            registerTLV("ResolvedTopCandidate_JESDown");    // resolved tops JES down
         }
         
         registerTLV("Electron");    // electrons

--- a/Tools/RunTopTagger.h
+++ b/Tools/RunTopTagger.h
@@ -24,7 +24,6 @@ class RunTopTagger {
 private:
     std::shared_ptr<TopTagger> tt_; // std::unique_ptr gives a compile error
     std::string jetsLabel_;
-    std::string resTopCandDiscLabel_;
     std::string taggerCfg_;
     std::string suffix_;
     bool doLeptonCleaning_ = false;
@@ -101,15 +100,14 @@ private:
         // --- old version --- //
         //resolved top candidates
         //const auto& ResTopCand_LV            = tr.getVec_LVFromNano<float>("ResolvedTopCandidate");
-        // load discriminator to fix double truncation/rounding
         //const auto& ResTopCand_discriminator = tr.getVec<float>("ResolvedTopCandidate_discriminator");
-        //const auto& ResTopCand_discriminator = tr.getVec<float>(resTopCandDiscLabel_);
         //const auto& ResTopCand_j1Idx         = tr.getVec<int>("ResolvedTopCandidate_j1Idx");
         //const auto& ResTopCand_j2Idx         = tr.getVec<int>("ResolvedTopCandidate_j2Idx");
         //const auto& ResTopCand_j3Idx         = tr.getVec<int>("ResolvedTopCandidate_j3Idx");
         
         // --- new version --- //
-        //resolved top candidates
+        // load previously run top tagger candidates to fix double truncation/rounding
+        // resolved top candidates
         const auto& ResTopCand_LV            = tr.getVec<TLorentzVector>(getSATVar("ResolvedTopCandidateTLV"));
         const auto& ResTopCand_discriminator = tr.getVec<float>(getSATVar("ResolvedTopCandidate_discriminator"));
         const auto& ResTopCand_j1Idx         = tr.getVec<int>(getSATVar("ResolvedTopCandidate_j1Idx"));
@@ -455,7 +453,7 @@ private:
     
 public:
 
-    int verbose_ = 1;
+    int verbose_ = 0;
 
     RunTopTagger(std::string taggerCfg = "TopTagger.cfg", std::string suffix = "", bool doLeptonCleaning = false, bool doPhotonCleaning = false) :
         taggerCfg_ (taggerCfg),
@@ -465,25 +463,18 @@ public:
         tt_ (new TopTagger())
     {
         jetsLabel_           = "JetTLV";
-        resTopCandDiscLabel_ = "ResolvedTopCandidate_discriminator"; 
-        if (doLeptonCleaning || doPhotonCleaning)
-        {
-            resTopCandDiscLabel_ = "SAT_ResolvedTopCandidate_discriminator_jetpt30";
-        }
         if (suffix_.find("jesTotalUp") != std::string::npos)
         {
             jetsLabel_              += "_jesTotalUp";
-            resTopCandDiscLabel_    += "_jesTotalUp";
         }
         else if (suffix_.find("jesTotalDown") != std::string::npos)
         {
             jetsLabel_              += "_jesTotalDown";
-            resTopCandDiscLabel_    += "_jesTotalDown";
         }
         if (verbose_) 
         {
             std::cout << "Constructing RunTopTagger; taggerCfg_ = " << taggerCfg_ << ", suffix_ = " << suffix_ << ", jetsLabel_ = " << jetsLabel_ 
-                      << ", resTopCandDiscLabel_ = " << resTopCandDiscLabel_ << ", doLeptonCleaning_ = " << doLeptonCleaning_ << ", doPhotonCleaning_ = " << doPhotonCleaning_ << std::endl;
+                      << ", doLeptonCleaning_ = " << doLeptonCleaning_ << ", doPhotonCleaning_ = " << doPhotonCleaning_ << std::endl;
         }
         tt_->setCfgFile(taggerCfg_);
     }

--- a/Tools/RunTopTagger.h
+++ b/Tools/RunTopTagger.h
@@ -29,15 +29,15 @@ private:
     bool doLeptonCleaning_ = false;
     bool doPhotonCleaning_ = false;
 
-    std::string getSATVar(std::string var)
+    std::string getSATVar(std::string collection, std::string var)
     {
         // only use SAT version of variable when doing lepton/photon cleaning (using top candidates which are already saved)
         // otherwise, we run the top tagger with Tensorflow and do not use the top candidates
         bool useSAT = doLeptonCleaning_ || doPhotonCleaning_;
-        std::string final_var = var;
+        std::string final_var = collection + var;
         if (useSAT) 
         {
-            final_var = "SAT_" + var + "_jetpt30";
+            final_var = "SAT_" + collection + var + "_jetpt30";
             if (suffix_.find("jesTotalUp") != std::string::npos)
             {
                 final_var += "_jesTotalUp";
@@ -45,6 +45,17 @@ private:
             else if (suffix_.find("jesTotalDown") != std::string::npos)
             {
                 final_var += "_jesTotalDown";
+            }
+        }
+        else
+        {
+            if (suffix_.find("jesTotalUp") != std::string::npos)
+            {
+                final_var = collection + "_JESUp" + var;
+            }
+            else if (suffix_.find("jesTotalDown") != std::string::npos)
+            {
+                final_var = collection + "_JESDown" + var;
             }
         }
         return final_var;
@@ -108,11 +119,12 @@ private:
         // --- new version --- //
         // load previously run top tagger candidates to fix double truncation/rounding
         // resolved top candidates
-        const auto& ResTopCand_LV            = tr.getVec<TLorentzVector>(getSATVar("ResolvedTopCandidateTLV"));
-        const auto& ResTopCand_discriminator = tr.getVec<float>(getSATVar("ResolvedTopCandidate_discriminator"));
-        const auto& ResTopCand_j1Idx         = tr.getVec<int>(getSATVar("ResolvedTopCandidate_j1Idx"));
-        const auto& ResTopCand_j2Idx         = tr.getVec<int>(getSATVar("ResolvedTopCandidate_j2Idx"));
-        const auto& ResTopCand_j3Idx         = tr.getVec<int>(getSATVar("ResolvedTopCandidate_j3Idx"));
+        // std::string getSATVar(std::string collection, std::string var)
+        const auto& ResTopCand_LV            = tr.getVec<TLorentzVector>(   getSATVar("ResolvedTopCandidate", "TLV")                );
+        const auto& ResTopCand_discriminator = tr.getVec<float>(            getSATVar("ResolvedTopCandidate", "_discriminator")     );
+        const auto& ResTopCand_j1Idx         = tr.getVec<int>(              getSATVar("ResolvedTopCandidate", "_j1Idx")             );
+        const auto& ResTopCand_j2Idx         = tr.getVec<int>(              getSATVar("ResolvedTopCandidate", "_j2Idx")             );
+        const auto& ResTopCand_j3Idx         = tr.getVec<int>(              getSATVar("ResolvedTopCandidate", "_j3Idx")             );
 
         auto* MergedTopsTLV                             = new std::vector<TLorentzVector>();
         auto* MergedTops_disc                           = new std::vector<float>();

--- a/Tools/RunTopTagger.h
+++ b/Tools/RunTopTagger.h
@@ -24,10 +24,32 @@ class RunTopTagger {
 private:
     std::shared_ptr<TopTagger> tt_; // std::unique_ptr gives a compile error
     std::string jetsLabel_;
+    std::string resTopCandDiscLabel_;
     std::string taggerCfg_;
     std::string suffix_;
     bool doLeptonCleaning_ = false;
     bool doPhotonCleaning_ = false;
+
+    std::string getSATVar(std::string var)
+    {
+        // only use SAT version of variable when doing lepton/photon cleaning (using top candidates which are already saved)
+        // otherwise, we run the top tagger with Tensorflow and do not use the top candidates
+        bool useSAT = doLeptonCleaning_ || doPhotonCleaning_;
+        std::string final_var = var;
+        if (useSAT) 
+        {
+            final_var = "SAT_" + var + "_jetpt30";
+            if (suffix_.find("jesTotalUp") != std::string::npos)
+            {
+                final_var += "_jesTotalUp";
+            }
+            else if (suffix_.find("jesTotalDown") != std::string::npos)
+            {
+                final_var += "_jesTotalDown";
+            }
+        }
+        return final_var;
+    }
 
     void runTopTagger(NTupleReader& tr) 
     {
@@ -76,24 +98,39 @@ private:
         //AK8 subjets 
         const auto& SubJet_LV = tr.getVec_LVFromNano<float>("SubJet");
         
+        // --- old version --- //
         //resolved top candidates
-        const auto& ResTopCand_LV            = tr.getVec_LVFromNano<float>("ResolvedTopCandidate");
-        const auto& ResTopCand_discriminator = tr.getVec<float>("ResolvedTopCandidate_discriminator");
-        const auto& ResTopCand_j1Idx         = tr.getVec<int>("ResolvedTopCandidate_j1Idx");
-        const auto& ResTopCand_j2Idx         = tr.getVec<int>("ResolvedTopCandidate_j2Idx");
-        const auto& ResTopCand_j3Idx         = tr.getVec<int>("ResolvedTopCandidate_j3Idx");
+        //const auto& ResTopCand_LV            = tr.getVec_LVFromNano<float>("ResolvedTopCandidate");
+        // load discriminator to fix double truncation/rounding
+        //const auto& ResTopCand_discriminator = tr.getVec<float>("ResolvedTopCandidate_discriminator");
+        //const auto& ResTopCand_discriminator = tr.getVec<float>(resTopCandDiscLabel_);
+        //const auto& ResTopCand_j1Idx         = tr.getVec<int>("ResolvedTopCandidate_j1Idx");
+        //const auto& ResTopCand_j2Idx         = tr.getVec<int>("ResolvedTopCandidate_j2Idx");
+        //const auto& ResTopCand_j3Idx         = tr.getVec<int>("ResolvedTopCandidate_j3Idx");
+        
+        // --- new version --- //
+        //resolved top candidates
+        const auto& ResTopCand_LV            = tr.getVec<TLorentzVector>(getSATVar("ResolvedTopCandidateTLV"));
+        const auto& ResTopCand_discriminator = tr.getVec<float>(getSATVar("ResolvedTopCandidate_discriminator"));
+        const auto& ResTopCand_j1Idx         = tr.getVec<int>(getSATVar("ResolvedTopCandidate_j1Idx"));
+        const auto& ResTopCand_j2Idx         = tr.getVec<int>(getSATVar("ResolvedTopCandidate_j2Idx"));
+        const auto& ResTopCand_j3Idx         = tr.getVec<int>(getSATVar("ResolvedTopCandidate_j3Idx"));
 
-
-
-        auto* MergedTopsTLV          = new std::vector<TLorentzVector>();
-        auto* MergedTops_disc        = new std::vector<double>();
-        auto* MergedTops_JetsMap     = new std::map< int , std::vector<TLorentzVector> >();
-        auto* WTLV                   = new std::vector<TLorentzVector>();
-        auto* W_disc                 = new std::vector<double>();
-        auto* W_JetsMap              = new std::map< int , std::vector<TLorentzVector> >();
-        auto* ResolvedTopsTLV        = new std::vector<TLorentzVector>();
-        auto* ResolvedTops_disc      = new std::vector<double>();
-        auto* ResolvedTops_JetsMap   = new std::map< int , std::vector<TLorentzVector> >();
+        auto* MergedTopsTLV                             = new std::vector<TLorentzVector>();
+        auto* MergedTops_disc                           = new std::vector<float>();
+        auto* MergedTops_JetsMap                        = new std::map< int , std::vector<TLorentzVector> >();
+        auto* WTLV                                      = new std::vector<TLorentzVector>();
+        auto* W_disc                                    = new std::vector<float>();
+        auto* W_JetsMap                                 = new std::map< int , std::vector<TLorentzVector> >();
+        auto* ResolvedTopsTLV                           = new std::vector<TLorentzVector>();
+        auto* ResolvedTops_disc                         = new std::vector<float>();
+        auto* ResolvedTops_JetsMap                      = new std::map< int , std::vector<TLorentzVector> >();
+        auto& SAT_ResolvedTopCandidate_TLV              = tr.createDerivedVec<TLorentzVector>("SAT_ResolvedTopCandidateTLV"   + suffix_);
+        auto& SAT_ResolvedTopCandidate_discriminator    = tr.createDerivedVec<float>("SAT_ResolvedTopCandidate_discriminator" + suffix_);
+        auto& SAT_ResolvedTopCandidate_j1Idx            = tr.createDerivedVec<int>("SAT_ResolvedTopCandidate_j1Idx"           + suffix_);
+        auto& SAT_ResolvedTopCandidate_j2Idx            = tr.createDerivedVec<int>("SAT_ResolvedTopCandidate_j2Idx"           + suffix_);
+        auto& SAT_ResolvedTopCandidate_j3Idx            = tr.createDerivedVec<int>("SAT_ResolvedTopCandidate_j3Idx"           + suffix_);
+        
         int nMergedTops                 = 0;
         int nWs                         = 0;
         int nResolvedTops               = 0;
@@ -255,7 +292,13 @@ private:
         std::vector<Constituent> constituents = packageConstituents(*ak4Inputs, resInputs, ak8Inputs);
         
         //run top tager
-        tt_->runTagger(constituents);
+        try {
+            tt_->runTagger(constituents);
+        }
+        catch (TTException e)
+        {
+            std::cout << "Here is your TTException: " << e << std::endl;
+        }
 
 
         // delete pointers
@@ -265,11 +308,34 @@ private:
 
         //get tagger results 
         const TopTaggerResults& ttr = tt_->getResults();
-
-        //print top properties
-        //get reconstructed tops
-        const std::vector<TopObject*>& tops = ttr.getTops();
         
+        //get tops and top candidates
+        const std::vector<TopObject*>& tops           = ttr.getTops();
+        const std::vector<TopObject>&  topCandidates  = ttr.getTopCandidates();
+        
+        /////////////////////////////////////////
+        // save top tagger candidate variables //
+        /////////////////////////////////////////
+        for(const TopObject topCand : topCandidates)
+        {
+            int nConstituents = topCand.getNConstituents();
+            //printf("nConstituents = %d\n", nConstituents);
+            std::vector<int> jetIdxs(3, -1);
+            for (int i = 0; i < 3; ++i)
+            {
+                // check that there are enough constituents before accessing
+                if (nConstituents > i)
+                {
+                    jetIdxs[i] = constituents[i].getIndex();
+                }
+            }
+            const std::vector<Constituent const *>& constituents = topCand.getConstituents();
+            SAT_ResolvedTopCandidate_TLV.push_back(topCand.p());
+            SAT_ResolvedTopCandidate_discriminator.push_back(topCand.getDiscriminator());
+            SAT_ResolvedTopCandidate_j1Idx.push_back(jetIdxs[0]);
+            SAT_ResolvedTopCandidate_j2Idx.push_back(jetIdxs[1]);
+            SAT_ResolvedTopCandidate_j3Idx.push_back(jetIdxs[2]);
+        }
 
         bool printTops = false;
 
@@ -362,34 +428,34 @@ private:
             std::cout << std::endl;
         }
         
-        tr.registerDerivedVar("nMergedTops" + suffix_,              nMergedTops);
-        tr.registerDerivedVar("MergedTopTotalSF" + suffix_,         MergedTopTotalSF);
-        tr.registerDerivedVar("MergedTopTotalSF_Up" + suffix_,      MergedTopTotalSF_Up);
-        tr.registerDerivedVar("MergedTopTotalSF_Down" + suffix_,    MergedTopTotalSF_Down);
-        tr.registerDerivedVec("MergedTopsTLV" + suffix_,            MergedTopsTLV);
-        tr.registerDerivedVec("MergedTops_disc" + suffix_,          MergedTops_disc);
-        tr.registerDerivedVec("MergedTops_JetsMap" + suffix_,       MergedTops_JetsMap);
-        tr.registerDerivedVar("nWs" + suffix_,                      nWs);
-        tr.registerDerivedVar("WTotalSF" + suffix_,                 WTotalSF);
-        tr.registerDerivedVar("WTotalSF_Up" + suffix_,              WTotalSF_Up);
-        tr.registerDerivedVar("WTotalSF_Down" + suffix_,            WTotalSF_Down);
-        tr.registerDerivedVec("WTLV" + suffix_,                     WTLV);
-        tr.registerDerivedVec("W_disc" + suffix_,                   W_disc);
-        tr.registerDerivedVec("W_JetsMap" + suffix_,                W_JetsMap);
-        tr.registerDerivedVar("nResolvedTops" + suffix_,            nResolvedTops);
-        tr.registerDerivedVar("ResolvedTopTotalSF" + suffix_,       ResolvedTopTotalSF);
-        tr.registerDerivedVar("ResolvedTopTotalSF_Up" + suffix_,    ResolvedTopTotalSF_Up);
-        tr.registerDerivedVar("ResolvedTopTotalSF_Down" + suffix_,  ResolvedTopTotalSF_Down);
-        tr.registerDerivedVec("ResolvedTopsTLV" + suffix_,          ResolvedTopsTLV);
-        tr.registerDerivedVec("ResolvedTops_disc" + suffix_,        ResolvedTops_disc);
-        tr.registerDerivedVec("ResolvedTops_JetsMap" + suffix_,     ResolvedTops_JetsMap);
-        tr.registerDerivedVar("ttr" + suffix_,                      &ttr);
-        tr.registerDerivedVec("genTops" + suffix_,                  genTops);
+        tr.registerDerivedVar("nMergedTops" + suffix_,                              nMergedTops);
+        tr.registerDerivedVar("MergedTopTotalSF" + suffix_,                         MergedTopTotalSF);
+        tr.registerDerivedVar("MergedTopTotalSF_Up" + suffix_,                      MergedTopTotalSF_Up);
+        tr.registerDerivedVar("MergedTopTotalSF_Down" + suffix_,                    MergedTopTotalSF_Down);
+        tr.registerDerivedVec("MergedTopsTLV" + suffix_,                            MergedTopsTLV);
+        tr.registerDerivedVec("MergedTops_disc" + suffix_,                          MergedTops_disc);
+        tr.registerDerivedVec("MergedTops_JetsMap" + suffix_,                       MergedTops_JetsMap);
+        tr.registerDerivedVar("nWs" + suffix_,                                      nWs);
+        tr.registerDerivedVar("WTotalSF" + suffix_,                                 WTotalSF);
+        tr.registerDerivedVar("WTotalSF_Up" + suffix_,                              WTotalSF_Up);
+        tr.registerDerivedVar("WTotalSF_Down" + suffix_,                            WTotalSF_Down);
+        tr.registerDerivedVec("WTLV" + suffix_,                                     WTLV);
+        tr.registerDerivedVec("W_disc" + suffix_,                                   W_disc);
+        tr.registerDerivedVec("W_JetsMap" + suffix_,                                W_JetsMap);
+        tr.registerDerivedVar("nResolvedTops" + suffix_,                            nResolvedTops);
+        tr.registerDerivedVar("ResolvedTopTotalSF" + suffix_,                       ResolvedTopTotalSF);
+        tr.registerDerivedVar("ResolvedTopTotalSF_Up" + suffix_,                    ResolvedTopTotalSF_Up);
+        tr.registerDerivedVar("ResolvedTopTotalSF_Down" + suffix_,                  ResolvedTopTotalSF_Down);
+        tr.registerDerivedVec("ResolvedTopsTLV" + suffix_,                          ResolvedTopsTLV);
+        tr.registerDerivedVec("ResolvedTops_disc" + suffix_,                        ResolvedTops_disc);
+        tr.registerDerivedVec("ResolvedTops_JetsMap" + suffix_,                     ResolvedTops_JetsMap);
+        tr.registerDerivedVar("ttr" + suffix_,                                      &ttr);
+        tr.registerDerivedVec("genTops" + suffix_,                                  genTops);
     }
     
 public:
 
-    int verbose_ = 0;
+    int verbose_ = 1;
 
     RunTopTagger(std::string taggerCfg = "TopTagger.cfg", std::string suffix = "", bool doLeptonCleaning = false, bool doPhotonCleaning = false) :
         taggerCfg_ (taggerCfg),
@@ -398,10 +464,27 @@ public:
         doPhotonCleaning_ (doPhotonCleaning),
         tt_ (new TopTagger())
     {
-        jetsLabel_ = "JetTLV";
-        if      (suffix.find("jesTotalUp") != std::string::npos)    jetsLabel_ = jetsLabel_ + "_jesTotalUp";
-        else if (suffix.find("jesTotalDown") != std::string::npos)  jetsLabel_ = jetsLabel_ + "_jesTotalDown";
-        if (verbose_) std::cout << "Constructing RunTopTagger; taggerCfg_ = " << taggerCfg_ << ", suffix_ = " << suffix_ << ", jetsLabel_ = " << jetsLabel_ << ", doLeptonCleaning_ = " << doLeptonCleaning_ << ", doPhotonCleaning_ = " << doPhotonCleaning_ << std::endl;
+        jetsLabel_           = "JetTLV";
+        resTopCandDiscLabel_ = "ResolvedTopCandidate_discriminator"; 
+        if (doLeptonCleaning || doPhotonCleaning)
+        {
+            resTopCandDiscLabel_ = "SAT_ResolvedTopCandidate_discriminator_jetpt30";
+        }
+        if (suffix_.find("jesTotalUp") != std::string::npos)
+        {
+            jetsLabel_              += "_jesTotalUp";
+            resTopCandDiscLabel_    += "_jesTotalUp";
+        }
+        else if (suffix_.find("jesTotalDown") != std::string::npos)
+        {
+            jetsLabel_              += "_jesTotalDown";
+            resTopCandDiscLabel_    += "_jesTotalDown";
+        }
+        if (verbose_) 
+        {
+            std::cout << "Constructing RunTopTagger; taggerCfg_ = " << taggerCfg_ << ", suffix_ = " << suffix_ << ", jetsLabel_ = " << jetsLabel_ 
+                      << ", resTopCandDiscLabel_ = " << resTopCandDiscLabel_ << ", doLeptonCleaning_ = " << doLeptonCleaning_ << ", doPhotonCleaning_ = " << doPhotonCleaning_ << std::endl;
+        }
         tt_->setCfgFile(taggerCfg_);
     }
     

--- a/Tools/SB2018.h
+++ b/Tools/SB2018.h
@@ -865,6 +865,16 @@ int SB_lowdm_validation_high_MET(int nb, int nSV, float ISRpt, float met)
 	return -1;
 }
 
+//================================low dm validation MET study=================================================
+int lowdm_validation_MET(float ISRpt, float met)
+{
+	if (ISRpt >= 200 && met >= 250 && met < 300) return 0;
+	if (ISRpt >= 200 && met >= 300 && met < 400) return 1;
+	if (ISRpt >= 200 && met >= 400 && met < 500) return 2;
+	if (ISRpt >= 200 && met >= 500) return 3;
+	return -1;
+}
+
 //================================copy of SB_lowdm_validation_high_MET, just for name consistency=================================================
 int SBv2_lowdm_validation_high_MET(int nb, int nSV, float ISRpt, float met) {return SB_lowdm_validation_high_MET(nb, nSV, ISRpt, met);}
 int SBv3_lowdm_validation_high_MET(int nb, int nSV, float ISRpt, float met) {return SB_lowdm_validation_high_MET(nb, nSV, ISRpt, met);}
@@ -926,6 +936,17 @@ int SBv3_highdm_validation(float mtb, int njets, int ntop, int nw, int nres, int
 	if (nb >=2 && mtb >= 175 && ntop ==0 && nres ==1 && nw ==0 && met >= 400) return 40;
 	if (nb >=2 && mtb >= 175 && ntop + nres + nw >=2 && met >= 250 && met < 400) return 41;
 	if (nb >=2 && mtb >= 175 && ntop + nres + nw >=2 && met >= 400) return 42;
+	return -1;
+}
+
+//================================high dm validation MET study=================================================
+int highdm_validation_MET(float mtb, int ntop, int nw, int nres, float met)
+{
+	if (mtb >= 175 && ntop ==0 && nres ==0 && nw ==0 && met >= 250 && met < 350) return 0;
+	if (mtb >= 175 && ntop ==0 && nres ==0 && nw ==0 && met >= 350 && met < 450) return 1;
+	if (mtb >= 175 && ntop ==0 && nres ==0 && nw ==0 && met >= 450 && met < 550) return 2;
+	if (mtb >= 175 && ntop ==0 && nres ==0 && nw ==0 && met >= 550 && met < 650) return 3;
+	if (mtb >= 175 && ntop ==0 && nres ==0 && nw ==0 && met >= 650) return 4;
 	return -1;
 }
 

--- a/Tools/baselineDef.cc
+++ b/Tools/baselineDef.cc
@@ -1994,6 +1994,7 @@ bool BaselineVessel::PassObjectVeto(std::vector<TLorentzVector> objects, float e
 // https://github.com/susy2015/NanoSUSY-tools/blob/master/python/modules/Stop0lBaselineProducer.py#L236-L239
 void BaselineVessel::PassHEMVeto()
 {
+    bool verbose = false;
     // check if we are running on data
     bool isData             = ! tr->checkBranch("genWeight");
     const auto& run         = tr->getVar<unsigned int>("run");
@@ -2060,8 +2061,7 @@ void BaselineVessel::PassHEMVeto()
     {
         SAT_HEMVetoWeight = 1.0;
     }
-    //if (false)
-    if (firstSpec.compare("_jetpt30") == 0)
+    if (verbose && firstSpec.compare("_jetpt30") == 0)
     {
         printf("SAT_Pass_HEMVeto_DataOnly = %d, SAT_Pass_HEMVeto_DataAndMC = %d, SAT_HEMVetoWeight = %f\n", SAT_Pass_HEMVeto_DataOnly, SAT_Pass_HEMVeto_DataAndMC, SAT_HEMVetoWeight);
     }

--- a/Tools/baselineDef.cc
+++ b/Tools/baselineDef.cc
@@ -2018,15 +2018,36 @@ void BaselineVessel::PassHEMVeto()
     SAT_Pass_HEMVeto = SAT_Pass_HEMVeto && PassObjectVeto(Electrons, narrow_eta_low, narrow_eta_high, narrow_phi_low, narrow_phi_high, min_electron_pt);
     SAT_Pass_HEMVeto = SAT_Pass_HEMVeto && PassObjectVeto(Photons,   narrow_eta_low, narrow_eta_high, narrow_phi_low, narrow_phi_high, min_photon_pt);
     SAT_Pass_HEMVeto = SAT_Pass_HEMVeto && PassObjectVeto(Jets,      wide_eta_low,   wide_eta_high,   wide_phi_low,   wide_phi_high,   jet_pt_cut);
-    // for data, only apply HEM veto to 2018 starting with run 319077
-    if (year.compare("2018") == 0 && isData)
+    
+    
+    // HEM vetos
+    // - Cut for Data only, used for running over all 2018 at once
+    // - Cut for Data and MC, used for running over 2018 pre/post HEM eras
+    bool SAT_Pass_HEMVeto_DataOnly  = SAT_Pass_HEMVeto; 
+    bool SAT_Pass_HEMVeto_DataAndMC = SAT_Pass_HEMVeto; 
+    
+    // only apply HEM veto in 2018
+    if (year.compare("2018") != 0)
     {
-        if (run < 319077)
+        SAT_Pass_HEMVeto           = true;
+        SAT_Pass_HEMVeto_DataOnly  = true; 
+        SAT_Pass_HEMVeto_DataAndMC = true;
+    }
+    else
+    {
+        // for data, only apply HEM veto to 2018 starting with run 319077
+        if (isData)
         {
-            SAT_Pass_HEMVeto = true;
+            if (run < 319077)
+            {
+                SAT_Pass_HEMVeto_DataOnly = true;
+            }
         }
-        // print for testing
-        //printf("run = %d, SAT_Pass_HEMVeto = %d\n", run, SAT_Pass_HEMVeto);
+        // only apply HEM veto cut to data when using HEM veto weight for MC
+        else
+        {
+            SAT_Pass_HEMVeto_DataOnly = true;
+        }
     }
     
     // get HEM veto weight
@@ -2039,15 +2060,15 @@ void BaselineVessel::PassHEMVeto()
     {
         SAT_HEMVetoWeight = 1.0;
     }
-    // print for testing
-    //if (firstSpec.compare("_jetpt30") == 0)
-    if (false)
+    //if (false)
+    if (firstSpec.compare("_jetpt30") == 0)
     {
-        printf("SAT_Pass_HEMVeto = %d, SAT_HEMVetoWeight = %f\n", SAT_Pass_HEMVeto, SAT_HEMVetoWeight);
+        printf("SAT_Pass_HEMVeto_DataOnly = %d, SAT_Pass_HEMVeto_DataAndMC = %d, SAT_HEMVetoWeight = %f\n", SAT_Pass_HEMVeto_DataOnly, SAT_Pass_HEMVeto_DataAndMC, SAT_HEMVetoWeight);
     }
     // register variables
-    tr->registerDerivedVar("SAT_Pass_HEMVeto"  + firstSpec, SAT_Pass_HEMVeto    );
-    tr->registerDerivedVar("SAT_HEMVetoWeight" + firstSpec, SAT_HEMVetoWeight   );
+    tr->registerDerivedVar("SAT_Pass_HEMVeto_DataOnly"   + firstSpec, SAT_Pass_HEMVeto_DataOnly     );
+    tr->registerDerivedVar("SAT_Pass_HEMVeto_DataAndMC"  + firstSpec, SAT_Pass_HEMVeto_DataAndMC    );
+    tr->registerDerivedVar("SAT_HEMVetoWeight"           + firstSpec, SAT_HEMVetoWeight             );
 }
 
 void BaselineVessel::GetPileupWeight()

--- a/Tools/baselineDef.cc
+++ b/Tools/baselineDef.cc
@@ -582,6 +582,7 @@ void BaselineVessel::PassBaseline()
   const auto& Jets          = tr->getVec<TLorentzVector>(jetVecLabel);
   const auto& Jet_sortedIdx = tr->getVec<int>("Jet_sortedIdx");
   const auto& FatJets       = tr->getVec<TLorentzVector>(jetVecLabelAK8);
+  const auto& SubJets       = tr->getVec<TLorentzVector>("SubJetTLV");
   const auto& met           = tr->getVar<float>(METLabel); 
   const auto& metphi        = tr->getVar<float>(METPhiLabel); 
 
@@ -643,6 +644,8 @@ void BaselineVessel::PassBaseline()
   const auto& ResolvedTopTotalSF    = tr->getVar<float>(UseSpecVar("ResolvedTopTotalSF"));
   const auto* ttr                   = tr->getVar<TopTaggerResults*>(UseSpecVar("ttr"));
   const auto& FatJet_Stop0l         = tr->getVec<int>(UseCleanedJetsVar("FatJet_Stop0l"));
+  const auto& FatJet_subJetIdx1     = tr->getVec<int>(UseCleanedJetsVar("FatJet_subJetIdx1"));
+  const auto& FatJet_subJetIdx2     = tr->getVec<int>(UseCleanedJetsVar("FatJet_subJetIdx2"));
   const auto& FatJet_msoftdrop      = tr->getVec<float>(UseCleanedJetsVar("FatJet_msoftdrop"));
   const auto& FatJet_deepTag_TvsQCD = tr->getVec<float>(UseCleanedJetsVar("FatJet_deepTag_TvsQCD"));
   const auto& FatJet_deepTag_WvsQCD = tr->getVec<float>(UseCleanedJetsVar("FatJet_deepTag_WvsQCD"));
@@ -1149,8 +1152,17 @@ void BaselineVessel::PassBaseline()
     j = 0;
     for (const auto& FatJet : FatJets)
     {
-      printf("FatJet_%d: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf), type=%d, mt-disc=%.5lf, w-disc=%.5lf, msoftdrop=%.5lf\n", j, FatJet.Pt(), FatJet.Eta(), FatJet.Phi(), FatJet.M(), FatJet_Stop0l[j], FatJet_deepTag_TvsQCD[j], FatJet_deepTag_WvsQCD[j], FatJet_msoftdrop[j]);
-      ++j;
+        printf("FatJet_%d: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf), type=%d, mt-disc=%.5lf, w-disc=%.5lf, msoftdrop=%.5lf\n", j, FatJet.Pt(), FatJet.Eta(), FatJet.Phi(), FatJet.M(), FatJet_Stop0l[j], FatJet_deepTag_TvsQCD[j], FatJet_deepTag_WvsQCD[j], FatJet_msoftdrop[j]);
+        // sub jets
+        std::vector<int> subJetIdxs;
+        subJetIdxs.push_back(FatJet_subJetIdx1[j]);
+        subJetIdxs.push_back(FatJet_subJetIdx2[j]);
+        for (int k = 0; k < subJetIdxs.size(); ++k)
+        {
+            TLorentzVector subjet = SubJets[subJetIdxs[k]];
+            printf("\t\tsub jet %d: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf)\n", k, subjet.Pt(), subjet.Eta(), subjet.Phi(), subjet.M());
+        }
+        ++j;
     }
     // for testing ISR jet pt
     int myISRJetIndex = GetISRJetIdx(true);

--- a/Tools/baselineDef.cc
+++ b/Tools/baselineDef.cc
@@ -1050,7 +1050,8 @@ void BaselineVessel::PassBaseline()
   bool topDifference = bool(Stop0l_nTop != nMergedTops || Stop0l_nResolved != nResolvedTops || Stop0l_nW != nWs);
   int totalTopsWs = nMergedTops + nResolvedTops + nWs; 
   //if ( firstSpec.compare("_jetpt30") == 0 )
-  if ( firstSpec.compare("_jetpt30") == 0 && Pass_LeptonVeto && (baselineDifference || topDifference))
+  //if ( firstSpec.compare("_jetpt30") == 0 && Pass_LeptonVeto && (baselineDifference || topDifference))
+  if (false)
   {
     //printf("WARNING: Difference in number of tops and/or Ws found!\n");
     printf("-----------------------------------------------------------------------------------------\n");
@@ -1152,17 +1153,21 @@ void BaselineVessel::PassBaseline()
     j = 0;
     for (const auto& FatJet : FatJets)
     {
-        printf("FatJet_%d: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf), type=%d, mt-disc=%.5lf, w-disc=%.5lf, msoftdrop=%.5lf\n", j, FatJet.Pt(), FatJet.Eta(), FatJet.Phi(), FatJet.M(), FatJet_Stop0l[j], FatJet_deepTag_TvsQCD[j], FatJet_deepTag_WvsQCD[j], FatJet_msoftdrop[j]);
-        // sub jets
-        std::vector<int> subJetIdxs;
-        subJetIdxs.push_back(FatJet_subJetIdx1[j]);
-        subJetIdxs.push_back(FatJet_subJetIdx2[j]);
-        for (int k = 0; k < subJetIdxs.size(); ++k)
+      printf("FatJet_%d: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf), type=%d, mt-disc=%.5lf, w-disc=%.5lf, msoftdrop=%.5lf\n", j, FatJet.Pt(), FatJet.Eta(), FatJet.Phi(), FatJet.M(), FatJet_Stop0l[j], FatJet_deepTag_TvsQCD[j], FatJet_deepTag_WvsQCD[j], FatJet_msoftdrop[j]);
+      // sub jets
+      std::vector<int> subJetIdxs;
+      subJetIdxs.push_back(FatJet_subJetIdx1[j]);
+      subJetIdxs.push_back(FatJet_subJetIdx2[j]);
+      for (int k = 0; k < subJetIdxs.size(); ++k)
+      {
+        int subJetIdx = subJetIdxs[k];
+        if (subJetIdx >= 0 && subJetIdx < SubJets.size())
         {
-            TLorentzVector subjet = SubJets[subJetIdxs[k]];
-            printf("\t\tsub jet %d: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf)\n", k, subjet.Pt(), subjet.Eta(), subjet.Phi(), subjet.M());
+          TLorentzVector subjet = SubJets[subJetIdxs[k]];
+          printf("\t\tsub jet %d: (pt=%.5lf, eta=%.5lf, phi=%.5lf, mass=%.5lf)\n", k, subjet.Pt(), subjet.Eta(), subjet.Phi(), subjet.M());
         }
-        ++j;
+      }
+      ++j;
     }
     // for testing ISR jet pt
     int myISRJetIndex = GetISRJetIdx(true);

--- a/Tools/baselineDef.cc
+++ b/Tools/baselineDef.cc
@@ -1888,7 +1888,6 @@ float BaselineVessel::coreMT2calc(const TLorentzVector & fatJet1LVec, const TLor
 void BaselineVessel::operator()(NTupleReader& tr_)
 {
   tr = &tr_;
-  GetPileupWeight();
   PrepMETUncluster();
   UseCleanedJets();
   CalcBottomVars();
@@ -2042,6 +2041,7 @@ void BaselineVessel::PassHEMVeto()
     SAT_Pass_HEMVeto = SAT_Pass_HEMVeto && PassObjectVeto(Photons,   narrow_eta_low, narrow_eta_high, narrow_phi_low, narrow_phi_high, min_photon_pt);
     SAT_Pass_HEMVeto = SAT_Pass_HEMVeto && PassObjectVeto(Jets,      wide_eta_low,   wide_eta_high,   wide_phi_low,   wide_phi_high,   jet_pt_cut);
     // get HEM veto weight
+    // WARNING: luminosities are hard coded here
     float lumi2018PreHEM    = 21068.576;
     float lumi2018PostHEM   = 38630.913;
     float lumi2018          = lumi2018PreHEM + lumi2018PostHEM;
@@ -2051,7 +2051,8 @@ void BaselineVessel::PassHEMVeto()
         SAT_HEMVetoWeight = 1.0;
     }
     // print for testing
-    if (firstSpec.compare("_jetpt30") == 0)
+    //if (firstSpec.compare("_jetpt30") == 0)
+    if (false)
     {
         printf("SAT_Pass_HEMVeto = %d, SAT_HEMVetoWeight = %f\n", SAT_Pass_HEMVeto, SAT_HEMVetoWeight);
     }
@@ -2065,6 +2066,7 @@ void BaselineVessel::GetPileupWeight()
     const auto& puWeight       = tr->getVar<float>("puWeight");
     const auto& puWeight2017BE = tr->getVar<float>("17BtoEpuWeight");
     const auto& puWeight2017F  = tr->getVar<float>("17FpuWeight");
+    // WARNING: luminosities are hard coded here
     float lumi2017BE         = 27987.721;
     float lumi2017F          = 13498.415;
     float lumi2017           = lumi2017BE + lumi2017F;

--- a/Tools/baselineDef.h
+++ b/Tools/baselineDef.h
@@ -111,7 +111,7 @@ public:
     void PassEventFilter();
     bool PassObjectVeto(std::vector<TLorentzVector> objects, float eta_low, float eta_high, float phi_low, float phi_high, float pt_low);
     void PassHEMVeto();
-    void GetPileup();
+    void GetPileupWeight();
     bool PrintoutConfig() const;
     bool CalcBottomVars();
     int  GetISRJetIdx(bool verbose=false); 

--- a/Tools/scripts/getStopCfg.sh
+++ b/Tools/scripts/getStopCfg.sh
@@ -26,15 +26,19 @@ SUPP_CFG=supplementaryFiles.cfg
 SETS_CFG_2016=sampleSets_PostProcessed_2016.cfg
 SETS_CFG_2017=sampleSets_PostProcessed_2017.cfg
 SETS_CFG_2018=sampleSets_PostProcessed_2018.cfg
+SETS_CFG_RUN2=sampleSets_PostProcessed_Run2.cfg
 COLL_CFG_2016=sampleCollections_2016.cfg
 COLL_CFG_2017=sampleCollections_2017.cfg
 COLL_CFG_2018=sampleCollections_2018.cfg
+COLL_CFG_RUN2=sampleCollections_Run2.cfg
 SETS_LINK_NAME_2016=$SETS_CFG_2016
 SETS_LINK_NAME_2017=$SETS_CFG_2017
 SETS_LINK_NAME_2018=$SETS_CFG_2018
+SETS_LINK_NAME_RUN2=$SETS_CFG_RUN2
 COLL_LINK_NAME_2016=$COLL_CFG_2016
 COLL_LINK_NAME_2017=$COLL_CFG_2017
 COLL_LINK_NAME_2018=$COLL_CFG_2018
+COLL_LINK_NAME_RUN2=$COLL_CFG_RUN2
 SUPP_FILE_DIR=supplementaryFiles
 TARBALL=SUPP_FILE_TARBALL.tar.gz
 
@@ -46,12 +50,14 @@ function print_help {
     echo "Options:"
     echo "    -t RELEASE_TAG :         This is the github release tag to check out (required option)"
     echo "    -d checkout_directory :  This is the directory where the configuration files will be downloaded to (default: .)"
-    echo "    -a SETS_LINK_NAME_2016 : Specify this option to name the softlink to \"$SETS_CFG_2016\" something other than \"$SETS_LINK_NAME_2016\""
-    echo "    -b SETS_LINK_NAME_2017 : Specify this option to name the softlink to \"$SETS_CFG_2017\" something other than \"$SETS_LINK_NAME_2017\""
-    echo "    -c SETS_LINK_NAME_2018 : Specify this option to name the softlink to \"$SETS_CFG_2018\" something other than \"$SETS_LINK_NAME_2018\""
-    echo "    -x COLL_LINK_NAME_2016 : Specify this option to name the softlink to \"$COLL_CFG_2016\" something other than \"$COLL_LINK_NAME_2016\""
-    echo "    -y COLL_LINK_NAME_2017 : Specify this option to name the softlink to \"$COLL_CFG_2017\" something other than \"$COLL_LINK_NAME_2017\""
-    echo "    -z COLL_LINK_NAME_2018 : Specify this option to name the softlink to \"$COLL_CFG_2018\" something other than \"$COLL_LINK_NAME_2018\""
+    echo "    -i SETS_LINK_NAME_2016 : Specify this option to name the softlink to \"$SETS_CFG_2016\" something other than \"$SETS_LINK_NAME_2016\""
+    echo "    -j SETS_LINK_NAME_2017 : Specify this option to name the softlink to \"$SETS_CFG_2017\" something other than \"$SETS_LINK_NAME_2017\""
+    echo "    -k SETS_LINK_NAME_2018 : Specify this option to name the softlink to \"$SETS_CFG_2018\" something other than \"$SETS_LINK_NAME_2018\""
+    echo "    -l SETS_LINK_NAME_RUN2 : Specify this option to name the softlink to \"$SETS_CFG_RUN2\" something other than \"$SETS_LINK_NAME_RUN2\""
+    echo "    -w COLL_LINK_NAME_2016 : Specify this option to name the softlink to \"$COLL_CFG_2016\" something other than \"$COLL_LINK_NAME_2016\""
+    echo "    -x COLL_LINK_NAME_2017 : Specify this option to name the softlink to \"$COLL_CFG_2017\" something other than \"$COLL_LINK_NAME_2017\""
+    echo "    -y COLL_LINK_NAME_2018 : Specify this option to name the softlink to \"$COLL_CFG_2018\" something other than \"$COLL_LINK_NAME_2018\""
+    echo "    -z COLL_LINK_NAME_RUN2 : Specify this option to name the softlink to \"$COLL_CFG_RUN2\" something other than \"$COLL_LINK_NAME_RUN2\""
     echo "    -e :                     Softlink pre-processed config files."
     echo "    -n :                     Download files without producing softlinks"
     echo "    -o :                     Overwrite the softlinks if they already exist"
@@ -78,17 +84,21 @@ while getopts "h?t:d:a:b:x:y:enov" opt; do
         ;;
     d)  CFG_DIRECTORY=$OPTARG
         ;;
-    a)  SETS_LINK_NAME_2016=$OPTARG
+    i)  SETS_LINK_NAME_2016=$OPTARG
         ;;
-    b)  SETS_LINK_NAME_2017=$OPTARG
+    j)  SETS_LINK_NAME_2017=$OPTARG
         ;;
-    c)  SETS_LINK_NAME_2018=$OPTARG
+    k)  SETS_LINK_NAME_2018=$OPTARG
         ;;
-    x)  COLL_LINK_NAME_2016=$OPTARG
+    l)  SETS_LINK_NAME_RUN2=$OPTARG
         ;;
-    y)  COLL_LINK_NAME_2017=$OPTARG
+    w)  COLL_LINK_NAME_2016=$OPTARG
         ;;
-    z)  COLL_LINK_NAME_2018=$OPTARG
+    x)  COLL_LINK_NAME_2017=$OPTARG
+        ;;
+    y)  COLL_LINK_NAME_2018=$OPTARG
+        ;;
+    z)  COLL_LINK_NAME_RUN2=$OPTARG
         ;;
     e) USE_PRE=1
         ;;
@@ -119,9 +129,11 @@ then
     SETS_CFG_2016=sampleSets_PreProcessed_2016.cfg
     SETS_CFG_2017=sampleSets_PreProcessed_2017.cfg
     SETS_CFG_2018=sampleSets_PreProcessed_2018.cfg
+    SETS_CFG_RUN2=sampleSets_PreProcessed_Run2.cfg
     SETS_LINK_NAME_2016=$SETS_CFG_2016
     SETS_LINK_NAME_2017=$SETS_CFG_2017
     SETS_LINK_NAME_2018=$SETS_CFG_2018
+    SETS_LINK_NAME_RUN2=$SETS_CFG_RUN2
 fi
 
 # get source directory of bash script
@@ -263,9 +275,11 @@ then
     ln $OVERWRITE -s $DOWNLOAD_DIR/$SETS_CFG_2016 $SETS_LINK_NAME_2016 > /dev/null 2>&1 
     ln $OVERWRITE -s $DOWNLOAD_DIR/$SETS_CFG_2017 $SETS_LINK_NAME_2017 > /dev/null 2>&1 
     ln $OVERWRITE -s $DOWNLOAD_DIR/$SETS_CFG_2018 $SETS_LINK_NAME_2018 > /dev/null 2>&1 
+    ln $OVERWRITE -s $DOWNLOAD_DIR/$SETS_CFG_RUN2 $SETS_LINK_NAME_RUN2 > /dev/null 2>&1 
     ln $OVERWRITE -s $DOWNLOAD_DIR/$COLL_CFG_2016 $COLL_LINK_NAME_2016 > /dev/null 2>&1
     ln $OVERWRITE -s $DOWNLOAD_DIR/$COLL_CFG_2017 $COLL_LINK_NAME_2017 > /dev/null 2>&1
     ln $OVERWRITE -s $DOWNLOAD_DIR/$COLL_CFG_2018 $COLL_LINK_NAME_2018 > /dev/null 2>&1
+    ln $OVERWRITE -s $DOWNLOAD_DIR/$COLL_CFG_RUN2 $COLL_LINK_NAME_RUN2 > /dev/null 2>&1
     # make list of files to tar
     if [[ -f $DOWNLOAD_DIR/$SUPP_CFG ]]
     then


### PR DESCRIPTION
- Weight to account for HEM veto cut in 2018
- Uses 2018 luminosities
- New validation bins for MET study from Hui
- Update top tagger to speed up use: run Tensorflow for nominal, JES up/down; for lepton/photon cleaned reload top tagger candidates
- Fix bug: only load resolved top JES up/down for MC